### PR TITLE
feat: add gh actions runner setup for mac on aws

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ SOURCES := $(shell find . -name "*.go" -not -path "./vendor/*")
 # LDFLAGS := $(VERSION_VARIABLES) -extldflags='-static' ${GO_EXTRA_LDFLAGS}
 LDFLAGS := $(VERSION_VARIABLES) ${GO_EXTRA_LDFLAGS}
 GCFLAGS := all=-N -l
+GOOS := $(shell go env GOOS)
+GOARCH := $(shell go env GOARCH)
 
 TOOLS_DIR := tools
 include tools/tools.mk
@@ -37,7 +39,7 @@ install: $(SOURCES)
 	go install -ldflags="$(LDFLAGS)" $(GO_EXTRA_BUILDFLAGS) ./cmd/mapt
 
 $(BUILD_DIR)/mapt: $(SOURCES)
-	GOOS=linux GOARCH=amd64 go build -gcflags="$(GCFLAGS)" -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/mapt $(GO_EXTRA_BUILDFLAGS) ./cmd/mapt
+	GOOS="$(GOOS)" GOARCH=$(GOARCH) go build -gcflags="$(GCFLAGS)" -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/mapt $(GO_EXTRA_BUILDFLAGS) ./cmd/mapt
  
 .PHONY: build
 build: $(BUILD_DIR)/mapt

--- a/pkg/provider/aws/action/mac/bootstrap.sh
+++ b/pkg/provider/aws/action/mac/bootstrap.sh
@@ -34,6 +34,11 @@ sudo sysadminctl -screenLock off -password "{{.Password}}"
 mkdir /Users/{{.Username}}/.ssh
 echo "{{.AuthorizedKey}}" | tee /Users/{{.Username}}/.ssh/authorized_keys
 
+# Install github-actions-runner if needed
+{{ if .InstallActionsRunner }}
+    {{- .ActionsRunnerSnippet }}
+{{ end }}
+
 # autologin to take effect
 # run reboot on background to successfully finish the remote exec of the script
 (sleep 2 && sudo reboot)&

--- a/pkg/provider/aws/action/mac/mac-machine.go
+++ b/pkg/provider/aws/action/mac/mac-machine.go
@@ -19,6 +19,7 @@ import (
 	"github.com/redhat-developer/mapt/pkg/provider/util/security"
 	"github.com/redhat-developer/mapt/pkg/util"
 	"github.com/redhat-developer/mapt/pkg/util/file"
+	"github.com/redhat-developer/mapt/pkg/util/ghactions"
 	"github.com/redhat-developer/mapt/pkg/util/logging"
 	resourcesUtil "github.com/redhat-developer/mapt/pkg/util/resources"
 
@@ -35,9 +36,11 @@ var BootstrapScript []byte
 
 // Need to extend this to also pass the key to be set up on each / create or replace
 type userDataValues struct {
-	Username      string
-	Password      string
-	AuthorizedKey string
+	Username             string
+	Password             string
+	AuthorizedKey        string
+	InstallActionsRunner bool
+	ActionsRunnerSnippet string
 }
 
 type locked struct {
@@ -385,7 +388,9 @@ func (r *MacRequest) getBootstrapScript(ctx *pulumi.Context) (
 				userDataValues{
 					defaultUsername,
 					password,
-					authorizedKey},
+					authorizedKey,
+					r.SetupGHActionsRunner,
+					ghactions.GetActionRunnerSnippetMacos()},
 				resourcesUtil.GetResourceName(r.Prefix, awsMacMachineID, "mac-bootstrap"),
 				string(BootstrapScript[:]))
 		}).(pulumi.StringOutput)

--- a/pkg/provider/aws/action/mac/types.go
+++ b/pkg/provider/aws/action/mac/types.go
@@ -31,6 +31,9 @@ type MacRequest struct {
 	replace bool
 	lock    bool
 
+	// setup as github actions runner
+	SetupGHActionsRunner bool
+
 	// This value wil be used to dynamically expand the pool size
 	// MaxPoolSize *int
 


### PR DESCRIPTION
this adds new flags to the command `mapt aws mac request` to to install github actions runner on the provisioned instance

it also adds the additional flags to get the various values needed to setup the github actions runner