### PR TITLE
ci: add github actions workflow to test self hosted runner

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -3,7 +3,7 @@ name: oci-builds
 on:
   push:
     branches: [ main ]
-    tags:        
+    tags:
       - '*'
   pull_request:
     branches: [ main ]
@@ -28,9 +28,8 @@ jobs:
       shell: bash
       run: |
         make oci-build
-        make oci-save    
+        make oci-save
         echo ${IMG} > mapt-image
-
 
     - name: Build image for Release
       if: ${{ github.event_name == 'push' }}
@@ -47,4 +46,4 @@ jobs:
       with:
         name: mapt
         path: mapt*
-    
+

--- a/.github/workflows/build-on-hosted-runner.yaml
+++ b/.github/workflows/build-on-hosted-runner.yaml
@@ -1,0 +1,42 @@
+name: build-on-hosted-runner
+
+on:
+  workflow_run:
+    workflows:
+      - oci-builds
+    types:
+      - completed
+
+jobs:
+  hosted_runner_provision:
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    uses: ./.github/workflows/provision-hosted-runner.yaml
+    with:
+      runner_repo: "https://github.com/${{github.repository}}"
+      operating_system: windows
+    secrets: inherit
+
+  test_run_selfhosted_runner:
+    runs-on: [self-hosted, x64, Windows]
+    needs: hosted_runner_provision
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - name: Test
+        run: go test -v ./...
+
+  destroy_hosted_runner:
+    needs:
+      - test_run_selfhosted_runner
+      - hosted_runner_provision
+    if: always() && !contains(needs.*.result, 'skipped') && !contains(needs.*.result, 'cancelled')
+    uses: ./.github/workflows/destroy-hosted-runner.yaml
+    with:
+      operating_system: windows
+    secrets: inherit

--- a/.github/workflows/destroy-hosted-runner.yaml
+++ b/.github/workflows/destroy-hosted-runner.yaml
@@ -1,0 +1,37 @@
+name: destroy-hosted-runner
+
+on:
+  workflow_call:
+    inputs:
+      operating_system:
+        required: true
+        type: string
+
+jobs:
+  remove_cloud_instance:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download mapt image from artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: mapt
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - name: Import mapt image
+        run: |
+          podman load -i mapt.tar
+          podman images
+      - name: Destroy instance
+        run: |
+          MAPT_IMAGE=$(cat mapt-image)
+          podman run --name mapt-destroy --rm \
+            -v ${PWD}:/workspace:z \
+            -e ARM_CLIENT_ID=${{secrets.ARM_CLIENT_ID}} \
+            -e ARM_CLIENT_SECRET=${{secrets.ARM_CLIENT_SECRET}} \
+            -e ARM_TENANT_ID=${{secrets.ARM_TENANT_ID}} \
+            -e ARM_SUBSCRIPTION_ID=${{secrets.ARM_SUBSCRIPTION_ID}} \
+            -e AZURE_STORAGE_ACCOUNT=${{secrets.AZURE_STORAGE_ACCOUNT}} \
+            -e AZURE_STORAGE_KEY=${{secrets.AZURE_STORAGE_KEY}} \
+            ${MAPT_IMAGE} azure ${{inputs.operating_system}} \
+              destroy --project-name "az-ghrunner" \
+              --backed-url "azblob://mapt-gh-runner-mapt-state/${{ github.repository }}-${{ github.run_id }}"

--- a/.github/workflows/provision-hosted-runner.yaml
+++ b/.github/workflows/provision-hosted-runner.yaml
@@ -1,0 +1,62 @@
+name: provision-hosted-runner
+
+on:
+  workflow_call:
+    inputs:
+      operating_system:
+        required: true
+        type: string
+      runner_repo:
+        required: true
+        type: string
+
+jobs:
+  provision_runner:
+    name: provision-runner
+    runs-on: ubuntu-24.04
+    steps:
+      - name: fetch token from API
+        id: fetch_token
+        run: |
+          curl -s -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{secrets.GH_PAT_TOKEN}}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{github.repository}}/actions/runners/registration-token > token
+          token=$(cat token | jq .token)
+          echo "::add-mask::$token"
+          echo "runner_token=$token" >> "$GITHUB_OUTPUT"
+
+      - name: Download mapt image from artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: mapt
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Import mapt image
+        run: |
+          podman load -i mapt.tar
+          podman images
+
+      - name: Run mapt
+        run: |
+          MAPT_IMAGE=$(cat mapt-image)
+          podman run --name mapt-create --rm \
+            -v ${PWD}:/workspace:z \
+            -e ARM_CLIENT_ID=${{secrets.ARM_CLIENT_ID}} \
+            -e ARM_CLIENT_SECRET=${{secrets.ARM_CLIENT_SECRET}} \
+            -e ARM_TENANT_ID=${{secrets.ARM_TENANT_ID}} \
+            -e ARM_SUBSCRIPTION_ID=${{secrets.ARM_SUBSCRIPTION_ID}} \
+            -e AZURE_STORAGE_ACCOUNT=${{secrets.AZURE_STORAGE_ACCOUNT}} \
+            -e AZURE_STORAGE_KEY=${{secrets.AZURE_STORAGE_KEY}} \
+            ${MAPT_IMAGE} azure ${{inputs.operating_system}} create \
+              --spot --project-name "az-ghrunner" --conn-details-output /workspace \
+              --backed-url "azblob://mapt-gh-runner-mapt-state/${{ github.repository }}-${{ github.run_id }}" \
+              --install-ghactions-runner --ghactions-runner-name "az-runner-${{inputs.operating_system}}-${{github.event.workflow_run.id}}" \
+              --ghactions-runner-repo "${{inputs.runner_repo}}" --ghactions-runner-token ${{steps.fetch_token.outputs.runner_token}}
+
+      - name: wait for runner to start accepting jobs
+        run: sleep 120
+


### PR DESCRIPTION
- [x] need to use a cloud storage for the backend, to be able to remove the instance after the job
- [x] Add `mapt destroy` job to remove provisioned instance