### PR TITLE
chore: push mapt pr images to ghcr registry

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -22,12 +22,13 @@ jobs:
       run: |
         IMG=ghcr.io/redhat-developer/mapt:pr-${{ github.event.number }} make oci-build
         podman save -o mapt.tar ghcr.io/redhat-developer/mapt:pr-${{ github.event.number }}     
+        echo "ghcr.io/redhat-developer/mapt:pr-${{ github.event.number }}" > mapt-image
 
     - name: Save image for PR
       uses: actions/upload-artifact@v4
       with:
-        name: mapt-pr-${{ github.event.number }}
-        path: mapt.tar
+        name: mapt
+        path: mapt*
 
     - name: Build image
       if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/push-oci.yml
+++ b/.github/workflows/push-oci.yml
@@ -1,0 +1,41 @@
+name: oci-push
+
+on:
+  workflow_run:
+    workflows: 
+    - oci-builds
+    types:
+      - completed
+  
+jobs:
+  push:
+    name: push
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' 
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download mapt assets
+        uses: actions/download-artifact@v4
+        with:
+          name: mapt
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push mapt
+        run: |
+          podman load -i mapt.tar 
+          podman push $(cat mapt-image)
+
+        
+      


### PR DESCRIPTION
This PR will allow to push images built from PRs to ghcr, this will help testing them out, specially if those are adding features required on other projects.