### PR TITLE
fix: Fedora ami name regex is no longer valid. 

### DIFF
--- a/pkg/provider/aws/action/fedora/constants.go
+++ b/pkg/provider/aws/action/fedora/constants.go
@@ -8,8 +8,8 @@ var (
 
 	// Official AMIs from Fedora use aarch64 format for arm64
 	amiRegex = map[string]string{
-		"x86_64": "Fedora-Cloud-Base-%s*x86_64*",
-		"arm64":  "Fedora-Cloud-Base-%s*aarch64*",
+		"x86_64": "Fedora-Cloud-Base-AmazonEC2.x86_64-%s*",
+		"arm64":  "Fedora-Cloud-Base-AmazonEC2.aarch64-%s*",
 	}
 	// This is the ID for AMIS from https://fedoraproject.org/cloud
 	amiOwner       = "125523088429"


### PR DESCRIPTION
This commit update the regex expresison used to get the official Fedora AMIs on AWS

Fix #321 