### PR TITLE
check if stack output map is empty before accessing

### DIFF
--- a/pkg/provider/aws/modules/spot/stack.go
+++ b/pkg/provider/aws/modules/spot/stack.go
@@ -1,6 +1,8 @@
 package spot
 
 import (
+	"errors"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/redhat-developer/mapt/pkg/manager"
@@ -132,6 +134,9 @@ func getOutputs(stack *auto.Stack) (*SpotOptionResult, error) {
 	outputs, err := manager.GetOutputs(stack)
 	if err != nil {
 		return nil, err
+	}
+	if len(outputs) == 0 {
+		return nil, errors.New("Stack outputs are empty please destroy and re-create")
 	}
 	return &SpotOptionResult{
 		Region:           outputs["region"].Value.(string),


### PR DESCRIPTION
with this, we get an error instead of a panic

```
% ./out/mapt aws fedora create --spot --airgap --nested-virt --cpus 6 --memory 16 --project-name aws-mapt-fedora-test --backed-url file:///Users/anath/workspace --conn-details-output /tmp/fedora --tags user=anath
DEBU running 'mapt aws fedora create'
DEBU context initialized for mapt6ca81181
DEBU checking stack spotOption-aws-mapt-fedora-test
ERRO Stack outputs are empty please destroy and re-create
```


fixes #327 