### PR TITLE
ci: update oci image tarball name in self-hosted runner workflows

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Prepare runner
       shell: bash
       run: |
-        sudo apt-get install -y qemu-user-static
+        sudo apt-get update && sudo apt-get install -y qemu-user-static
 
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/destroy-hosted-runner.yaml
+++ b/.github/workflows/destroy-hosted-runner.yaml
@@ -19,7 +19,7 @@ jobs:
           github-token: ${{ github.token }}
       - name: Import mapt image
         run: |
-          podman load -i mapt.tar
+          podman load -i mapt-amd64.tar
           podman images
       - name: Destroy instance
         run: |

--- a/.github/workflows/provision-hosted-runner.yaml
+++ b/.github/workflows/provision-hosted-runner.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Import mapt image
         run: |
-          podman load -i mapt.tar
+          podman load -i mapt-amd64.tar
           podman images
 
       - name: Run mapt


### PR DESCRIPTION
the output tarball name for `podman save` commands in the build-oci workflows were updated as part of the multi-arch image work and now contains the arch as suffix