### PR TITLE
ci: build image for self hosted gh runner test

### DIFF
--- a/.github/workflows/build-img-ghrunner-test.yaml
+++ b/.github/workflows/build-img-ghrunner-test.yaml
@@ -1,0 +1,43 @@
+name: build-img-ghrunner-test
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'pkg/util/ghactions/*.go'
+      - '.github/workflows/build-img-ghrunner-test.yaml'
+
+jobs:
+  build-mapt:
+    name: build-mapt
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Prepare runner
+      shell: bash
+      run: |
+        sudo apt-get update && sudo apt-get install -y qemu-user-static
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Build image for PR
+      if: ${{ github.event_name == 'pull_request' }}
+      env:
+        IMG: ghcr.io/redhat-developer/mapt-img-ghrunner-test:pr-${{ github.event.number }}
+      shell: bash
+      run: |
+        make oci-build
+        make oci-save
+        echo ${IMG} > mapt-image
+
+    - name: Create image metadata
+      run: |
+        echo ${{ github.event_name }} > mapt-event
+        cat ./mapt-event
+
+    - name: Upload crc-builder
+      uses: actions/upload-artifact@v4
+      with:
+        name: mapt
+        path: mapt*
+

--- a/.github/workflows/build-on-hosted-runner.yaml
+++ b/.github/workflows/build-on-hosted-runner.yaml
@@ -3,7 +3,7 @@ name: build-on-hosted-runner
 on:
   workflow_run:
     workflows:
-      - oci-builds
+      - build-img-ghrunner-test
     types:
       - completed
 


### PR DESCRIPTION
this workflow uses path filters and runs only when files related to self hosted runner code changes

it then triggers the workflow for the  self hosted runner test, making the workflow run only for file changes in the self hosted runner modules