### PR TITLE
fix: default workdir with rights for any user

### DIFF
--- a/oci/Containerfile
+++ b/oci/Containerfile
@@ -24,17 +24,15 @@ LABEL org.opencontainers.image.authors="Redhat Developer"
 
 COPY --from=builder /workspace/out/mapt /workspace/pulumi/pulumi /usr/local/bin/
 
-ENV PULUMI_CONFIG_PASSPHRASE="passphrase" \
-    AWS_SDK_LOAD_CONFIG=1
+ENV PULUMI_CONFIG_PASSPHRASE "passphrase" 
 
-ENV AWS_CLI_VERSION 2.16.7
-ENV AZ_CLI_VERSION 2.61.0
+ENV AWS_SDK_LOAD_CONFIG=1 \
+    AWS_CLI_VERSION=2.16.7 \
+    AZ_CLI_VERSION=2.61.0
 
 # Pulumi plugins
 # renovate: datasource=github-releases depName=pulumi/pulumi-aws
 ARG PULUMI_AWS_VERSION=v6.64.0
-# Install this
-# https://releases.hashicorp.com/terraform-provider-aws/5.75.1/terraform-provider-aws_5.75.1_linux_amd64.zip
 # renovate: datasource=github-releases depName=pulumi/pulumi-azure-native
 ARG PULUMI_AZURE_NATIVE_VERSION=v2.76.0
 # renovate: datasource=github-releases depName=pulumi/pulumi-command
@@ -44,7 +42,9 @@ ARG PULUMI_TLS_VERSION=v5.0.9
 # renovate: datasource=github-releases depName=pulumi/pulumi-random
 ARG PULUMI_RANDOM_VERSION=v4.16.7
 
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
+RUN mkdir -p /opt/mapt/run \
+    && chmod -R 0777 /opt/mapt/run \
+    && if [ "$TARGETARCH" = "amd64" ]; then \
         export ARCH_N=x86_64; \ 
     else \
         export ARCH_N=aarch64; \
@@ -61,15 +61,14 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     && rm -rf aws awscliv2.zip azure-cli.rpm \
     && dnf clean all \
   	&& rm -rf /var/cache/yum \
-    && mkdir -p /opt/mapt/run \
-    && chmod -R 0777 /opt/mapt/run \
     && pulumi plugin install resource aws ${PULUMI_AWS_VERSION} \
     && pulumi plugin install resource azure-native ${PULUMI_AZURE_NATIVE_VERSION} \
     && pulumi plugin install resource command ${PULUMI_COMMAND_VERSION} \
     && pulumi plugin install resource tls ${PULUMI_TLS_VERSION} \
     && pulumi plugin install resource random ${PULUMI_RANDOM_VERSION}
 
-WORKDIR /opt/mapt/run
+ENV PULUMI_HOME "/opt/mapt/run" 
+WORKDIR ${PULUMI_HOME}
 
 ENTRYPOINT ["mapt"]
 # Default to show help

--- a/oci/Containerfile
+++ b/oci/Containerfile
@@ -1,5 +1,5 @@
-# go toolset 1.21.13-2.1727893526
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:fd41c001abc243076cc28b63c409ae6d9cbcad401c8124fb67d20fe57a2aa63a as builder
+# go toolset 9.5-1733160835-1.22.7-1733160835
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.7-1733160835 as builder
 ARG TARGETARCH
 USER root
 WORKDIR /workspace
@@ -17,18 +17,15 @@ RUN GOARCH=${TARGETARCH} make build \
     && curl -L ${PULUMI_URL} -o pulumicli.tar.gz \
     && tar -xzvf pulumicli.tar.gz 
 
-# ubi 9.4-1214.1726694543 
-FROM registry.access.redhat.com/ubi9/ubi@sha256:b00d5990a00937bd1ef7f44547af6c7fd36e3fd410e2c89b5d2dfc1aff69fe99
+# ubi 9.5-1732804088
+FROM registry.access.redhat.com/ubi9/ubi:9.5-1732804088
 ARG TARGETARCH
 LABEL org.opencontainers.image.authors="Redhat Developer"
 
 COPY --from=builder /workspace/out/mapt /workspace/pulumi/pulumi /usr/local/bin/
 
-ENV INTERNAL_OUTPUT=/tmp/mapt \
-    PULUMI_CONFIG_PASSPHRASE="passphrase" \
+ENV PULUMI_CONFIG_PASSPHRASE="passphrase" \
     AWS_SDK_LOAD_CONFIG=1
-
-VOLUME [ "${INTERNAL_OUTPUT}" ]
 
 ENV AWS_CLI_VERSION 2.16.7
 ENV AZ_CLI_VERSION 2.61.0
@@ -57,22 +54,22 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     && echo ${AWS_CLI_URL} ${AZ_CLI_RPM} \
     && curl ${AWS_CLI_URL} -o awscliv2.zip \
     && dnf install -y unzip \
-    && unzip awscliv2.zip \
+    && unzip -qq awscliv2.zip \
     && ./aws/install \
     && curl -L ${AZ_CLI_RPM} -o azure-cli.rpm \
     && dnf install -y azure-cli.rpm \
     && rm -rf aws awscliv2.zip azure-cli.rpm \
     && dnf clean all \
   	&& rm -rf /var/cache/yum \
-    && mkdir -p "${INTERNAL_OUTPUT}" \
+    && mkdir -p /opt/mapt/run \
+    && chmod -R 0777 /opt/mapt/run \
     && pulumi plugin install resource aws ${PULUMI_AWS_VERSION} \
     && pulumi plugin install resource azure-native ${PULUMI_AZURE_NATIVE_VERSION} \
     && pulumi plugin install resource command ${PULUMI_COMMAND_VERSION} \
     && pulumi plugin install resource tls ${PULUMI_TLS_VERSION} \
     && pulumi plugin install resource random ${PULUMI_RANDOM_VERSION}
 
-# TODO review permissions on sharing mounting volume from host
-# USER 65532:65532
+WORKDIR /opt/mapt/run
 
 ENTRYPOINT ["mapt"]
 # Default to show help


### PR DESCRIPTION
Previously workdir was / and only root user was able to write there, when running mapt on an ocp cluster with security context enable and non-root user mapt fail as it requires to create some ephemeral files on the current workdir. This commit will create a path on the image with open rights and set it as workdir to allow create the required files.

Fix #350 