### PR TITLE
check if best spot price location supports resource group

### DIFF
--- a/pkg/provider/azure/action/aks/aks.go
+++ b/pkg/provider/azure/action/aks/aks.go
@@ -59,10 +59,12 @@ func (r *AKSRequest) deployer(ctx *pulumi.Context) error {
 	if err != nil {
 		return err
 	}
+	// Get location for creating Resouce Group
+	rgLocation := azure.GetSuitableLocationForResourceGroup(*location)
 	rg, err := resources.NewResourceGroup(ctx,
 		resourcesUtil.GetResourceName(r.Prefix, azureAKSID, "rg"),
 		&resources.ResourceGroupArgs{
-			Location:          pulumi.String(*location),
+			Location:          pulumi.String(rgLocation),
 			ResourceGroupName: pulumi.String(maptContext.RunID()),
 			Tags:              maptContext.ResourceTags(),
 		})

--- a/pkg/provider/azure/action/linux/linux.go
+++ b/pkg/provider/azure/action/linux/linux.go
@@ -84,10 +84,13 @@ func (r *LinuxRequest) deployer(ctx *pulumi.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Get location for creating the Resource Group
+	rgLocation := azure.GetSuitableLocationForResourceGroup(*location)
 	rg, err := resources.NewResourceGroup(ctx,
 		resourcesUtil.GetResourceName(r.Prefix, azureLinuxID, "rg"),
 		&resources.ResourceGroupArgs{
-			Location:          pulumi.String(*location),
+			Location:          pulumi.String(rgLocation),
 			ResourceGroupName: pulumi.String(maptContext.RunID()),
 			Tags:              maptContext.ResourceTags(),
 		})

--- a/pkg/provider/azure/action/windows/windows.go
+++ b/pkg/provider/azure/action/windows/windows.go
@@ -90,10 +90,12 @@ func (r *WindowsRequest) deployer(ctx *pulumi.Context) error {
 	if err != nil {
 		return err
 	}
+	// Get location for creating Resource Group
+	rgLocation := azure.GetSuitableLocationForResourceGroup(*location)
 	rg, err := resources.NewResourceGroup(ctx,
 		resourcesUtil.GetResourceName(r.Prefix, azureWindowsDesktopID, "rg"),
 		&resources.ResourceGroupArgs{
-			Location:          pulumi.String(*location),
+			Location:          pulumi.String(rgLocation),
 			ResourceGroupName: pulumi.String(maptContext.RunID()),
 			Tags:              maptContext.ResourceTags(),
 		})

--- a/pkg/provider/azure/azure.go
+++ b/pkg/provider/azure/azure.go
@@ -1,6 +1,8 @@
 package azure
 
 import (
+	"slices"
+
 	"github.com/redhat-developer/mapt/pkg/manager"
 	"github.com/redhat-developer/mapt/pkg/manager/credentials"
 )
@@ -11,7 +13,55 @@ func GetClouProviderCredentials(fixedCredentials map[string]string) credentials.
 		FixedCredentials:  fixedCredentials}
 }
 
-var DefaultCredentials = GetClouProviderCredentials(nil)
+var (
+	DefaultCredentials               = GetClouProviderCredentials(nil)
+	locationsSupportingResourceGroup = []string{
+		"eastasia",
+		"southeastasia",
+		"australiaeast",
+		"australiasoutheast",
+		"brazilsouth",
+		"canadacentral",
+		"canadaeast",
+		"switzerlandnorth",
+		"germanywestcentral",
+		"eastus2",
+		"eastus",
+		"centralus",
+		"northcentralus",
+		"francecentral",
+		"uksouth",
+		"ukwest",
+		"centralindia",
+		"southindia",
+		"jioindiawest",
+		"italynorth",
+		"japaneast",
+		"japanwest",
+		"koreacentral",
+		"koreasouth",
+		"mexicocentral",
+		"northeurope",
+		"norwayeast",
+		"polandcentral",
+		"qatarcentral",
+		"spaincentral",
+		"swedencentral",
+		"uaenorth",
+		"westcentralus",
+		"westeurope",
+		"westus2",
+		"westus",
+		"southcentralus",
+		"westus3",
+		"southafricanorth",
+		"australiacentral",
+		"australiacentral2",
+		"israelcentral",
+		"westindia",
+		"newzealandnorth",
+	}
+)
 
 func Destroy(projectName, backedURL, stackName string) error {
 	stack := manager.Stack{
@@ -20,4 +70,16 @@ func Destroy(projectName, backedURL, stackName string) error {
 		BackedURL:           backedURL,
 		ProviderCredentials: DefaultCredentials}
 	return manager.DestroyStack(stack)
+}
+
+func locationSupportsResourceGroup(location string) bool {
+	return slices.Contains(locationsSupportingResourceGroup, location)
+}
+
+func GetSuitableLocationForResourceGroup(location string) string {
+	if locationSupportsResourceGroup(location) {
+		return location
+	}
+
+	return locationsSupportingResourceGroup[0]
 }


### PR DESCRIPTION
it is found that the location suggested by the spot calculation sometimes do not support the creation of Resource Groups  which is a requirement for `mapt` in those cases we use a pre-defined location for creating the Resource group

related issue: #313 