### PR TITLE
fix: add suffix to image used to test the self hosted runner

### DIFF
--- a/.github/workflows/provision-hosted-runner.yaml
+++ b/.github/workflows/provision-hosted-runner.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Run mapt
         run: |
-          MAPT_IMAGE=$(cat mapt-image)
+          MAPT_IMAGE=$(cat mapt-image)-amd64
           podman run --name mapt-create --rm \
             -v ${PWD}:/workspace:z \
             -e ARM_CLIENT_ID=${{secrets.ARM_CLIENT_ID}} \


### PR DESCRIPTION
The gh worflow for testing the feature was missing the arch suffix, added recently to support multi-arch oci mapt. This commit will match the load of the image and its name used to provision the selfhosted runner