### PR TITLE
ci : Move arm64 platform image build to a separate github workflow

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 name: oci-builds
 
 on:
@@ -9,56 +25,65 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-    name: build
-    runs-on: ubuntu-24.04
+  build-and-upload:
+    name: Build and Upload Images
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     steps:
-      - name: Prepare runner for build multi arch
-        shell: bash
-        run: |
-          sudo apt-get update && sudo apt-get install -y qemu-user-static
-
       - name: Checkout code
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install Podman (only for arm64)
+        if: contains(matrix.os, 'arm')
+        run: |
+          sudo apt-get update -y
+          sudo apt-get -y install podman
+      - name: Set environment variables based on architecture
+        run: |
+          if [[ "${{ matrix.os }}" == *"arm"* ]]; then
+            echo "ARCH_TYPE=arm64" >> $GITHUB_ENV
+          else
+            echo "ARCH_TYPE=amd64" >> $GITHUB_ENV
+          fi
       - name: Build image for PR
-        if: github.event_name == 'pull_request' 
+        if: github.event_name == 'pull_request'
         env:
           IMG: ghcr.io/redhat-developer/mapt:pr-${{ github.event.number }}
         shell: bash
         run: |
-          make oci-build
-          make oci-save
+          make oci-build-${{ env.ARCH_TYPE }}
+          make oci-save-${{ env.ARCH_TYPE }}
           echo ${IMG} > mapt-image
 
       - name: Build and Push image for Release
         if: github.event_name == 'push'
         run: |
-          make oci-build
-          make oci-save
+          make oci-build-${{ env.ARCH_TYPE }}
+          make oci-save-${{ env.ARCH_TYPE }}
 
       - name: Upload mapt artifacts for PR
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: mapt
+          name: mapt-${{ env.ARCH_TYPE }}
           path: mapt*
 
   push:
     name: push
-    if: github.event_name == 'push' 
-    needs: build
+    if: github.event_name == 'push'
+    needs: build-and-upload
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download mapt oci flatten images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          name: mapt
+          pattern: mapt-*         
         
       - name: Log in quay.io
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_IO_USERNAME }}
@@ -69,6 +94,3 @@ jobs:
         run: |
           make oci-load
           make oci-push
-
-      
-

--- a/.github/workflows/push-oci-pr.yml
+++ b/.github/workflows/push-oci-pr.yml
@@ -1,3 +1,19 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 name: oci-pr-push
 
 on:
@@ -19,18 +35,18 @@ jobs:
       packages: write
     steps:
       - name: Download mapt assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          name: mapt
+          pattern: mapt-*
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
       
-      - name: Get mapt build informaiton
+      - name: Get mapt build information
         run: |
           echo "image=$(cat mapt-image)" >> "$GITHUB_ENV"
 
       - name: Log in to ghcr.io
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
# Description

~⚠️ This is still work in progress. I haven't verified that behavior is still same as single target yet.~

Related to #364

Split oci-build Makefile target into different targets for handling amd64 and arm64 platforms separately.

Use a separate github action workflow to invoke separated Makefile targets to create container images