### PR TITLE
ci : Add a check in push workflow to only execute when an artifact is present

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -54,20 +54,35 @@ jobs:
         run: |
           make oci-build-${{ env.ARCH_TYPE }}
           make oci-save-${{ env.ARCH_TYPE }}
-          echo ${IMG} > mapt-image
-
       - name: Build and Push image for Release
         if: github.event_name == 'push'
         run: |
           make oci-build-${{ env.ARCH_TYPE }}
           make oci-save-${{ env.ARCH_TYPE }}
-
       - name: Upload mapt artifacts for PR
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mapt-${{ env.ARCH_TYPE }}
           path: mapt*
-
+  combine-artifacts:
+    name: combine-artifacts
+    needs: build-and-upload
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download mapt oci flatten images
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          pattern: mapt-*
+      - name: copy both artifacts into single directory
+        env:
+          IMG: ghcr.io/redhat-developer/mapt:pr-${{ github.event.number }}
+        run: echo ${IMG} > mapt-image
+      - name: Upload combined mapt artifacts for PR
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: mapt-arm64-and-amd64
+          path: mapt-*
   push:
     name: push
     if: github.event_name == 'push'

--- a/.github/workflows/push-oci-pr.yml
+++ b/.github/workflows/push-oci-pr.yml
@@ -25,7 +25,7 @@ on:
   
 jobs:
   push:
-    name: push
+    name: artifact-check-then-push
     if: |
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
@@ -37,28 +37,39 @@ jobs:
       - name: Download mapt assets
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
-          pattern: mapt-*
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
-      
+          name: mapt-arm64-and-amd64
+        continue-on-error: true
+      - name: Check if Artifact is Present
+        id: artifact-check
+        run: |
+          if [ -d "mapt-amd64" ] && [ -d "mapt-arm64" ]; then
+            echo "Artifacts found."
+            echo "found=true" >> $GITHUB_ENV
+          else
+            echo "Artifacts not found."
+            echo "found=false" >> $GITHUB_ENV
+          fi
       - name: Get mapt build information
+        if: env.found == 'true'
         run: |
           echo "image=$(cat mapt-image)" >> "$GITHUB_ENV"
-
       - name: Log in to ghcr.io
+        if: env.found == 'true'
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-    
       - name: Push mapt
+        if: env.found == 'true'
         run: |
           # Load images from build
-          podman load -i mapt-arm64.tar
-          podman load -i mapt-amd64.tar 
-          
+          podman load -i mapt-arm64/mapt-arm64.tar
+          podman load -i mapt-amd64/mapt-amd64.tar 
+
           # Push
           podman push ${{ env.image }}-arm64
           podman push ${{ env.image }}-amd64


### PR DESCRIPTION
## Description

Fix #418 

Due to split of build amd and arm workflows, push workflow_run is getting triggered multiple times.

+ Add another job that would combine both  image artifacts into one artifact. 
+ In push_pr workflow, add a condition to only execute workflow when both `mapt-amd64.tar` and `mapt-arm64.tar` artifacts are found.