### PR TITLE
fix: userdata on Azure Linux machines check if function is nil

### DIFF
--- a/pkg/provider/azure/action/linux/linux.go
+++ b/pkg/provider/azure/action/linux/linux.go
@@ -137,9 +137,13 @@ func (r *LinuxRequest) deployer(ctx *pulumi.Context) error {
 	if err != nil {
 		return err
 	}
-	userDataB64, err := r.GetUserdata()
-	if err != nil {
-		return fmt.Errorf("error creating RHEL Server on Azure: %v", err)
+	var userDataB64 string
+	if r.GetUserdata != nil {
+		var err error
+		userDataB64, err = r.GetUserdata()
+		if err != nil {
+			return fmt.Errorf("error creating RHEL Server on Azure: %v", err)
+		}
 	}
 	vmr := virtualmachine.VirtualMachineRequest{
 		Prefix:          r.Prefix,


### PR DESCRIPTION
This is a regression of d37ee99592144b2edb900e1c0742b1a6efb0852d we need to check if a specific type of Linux has a function defined to get the user data. Fix #425