### PR TITLE
fix: gh action missing merge conflict

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -38,11 +38,7 @@ jobs:
           make oci-save
 
       - name: Upload mapt artifacts for PR
-<<<<<<< HEAD
-        uses: actions/upload-artifact@v4
-=======
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
->>>>>>> 7c60066b (fix(deps): update patch updates)
         with:
           name: mapt
           path: mapt*
@@ -57,11 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download mapt oci flatten images
-<<<<<<< HEAD
-        uses: actions/download-artifact@v4
-=======
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
->>>>>>> 20137e84 (fix(deps): update all dependencies)
         with:
           name: mapt
         

--- a/.github/workflows/push-oci-pr.yml
+++ b/.github/workflows/push-oci-pr.yml
@@ -19,11 +19,7 @@ jobs:
       packages: write
     steps:
       - name: Download mapt assets
-<<<<<<< HEAD
-        uses: actions/download-artifact@v4
-=======
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
->>>>>>> 20137e84 (fix(deps): update all dependencies)
         with:
           name: mapt
           run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
When cherry-picking commits to 0.8 branch we missed conflicts on the gh action files. This commit solves the missing conflicts

Signed-off-by: Adrian Riobo <ariobolo@redhat.com>