### PR TITLE
ci : fix build-img-ghrunner-test pipeline as per image arch split

### DIFF
--- a/.github/workflows/build-img-ghrunner-test.yaml
+++ b/.github/workflows/build-img-ghrunner-test.yaml
@@ -12,11 +12,6 @@ jobs:
     name: build-mapt
     runs-on: ubuntu-24.04
     steps:
-    - name: Prepare runner
-      shell: bash
-      run: |
-        sudo apt-get update && sudo apt-get install -y qemu-user-static
-
     - name: Checkout code
       uses: actions/checkout@v4
 
@@ -26,8 +21,8 @@ jobs:
         IMG: ghcr.io/redhat-developer/mapt-img-ghrunner-test:pr-${{ github.event.number }}
       shell: bash
       run: |
-        make oci-build
-        make oci-save
+        make oci-build-amd64
+        make oci-save-amd64
         echo ${IMG} > mapt-image
 
     - name: Create image metadata
@@ -38,6 +33,6 @@ jobs:
     - name: Upload crc-builder
       uses: actions/upload-artifact@v4
       with:
-        name: mapt
+        name: mapt-${{ env.ARCH_TYPE }}
         path: mapt*
 

--- a/.github/workflows/provision-hosted-runner.yaml
+++ b/.github/workflows/provision-hosted-runner.yaml
@@ -31,18 +31,18 @@ jobs:
       - name: Download mapt image from artifacts
         uses: actions/download-artifact@v4
         with:
-          name: mapt
+          pattern: mapt*
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
       - name: Import mapt image
         run: |
-          podman load -i mapt-amd64.tar
+          podman load -i mapt-amd64/mapt-amd64.tar
           podman images
 
       - name: Run mapt
         run: |
-          MAPT_IMAGE=$(cat mapt-image)-amd64
+          MAPT_IMAGE=$(cat mapt-amd64/mapt-image)-amd64
           podman run --name mapt-create --rm \
             -v ${PWD}:/workspace:z \
             -e ARM_CLIENT_ID=${{secrets.ARM_CLIENT_ID}} \


### PR DESCRIPTION
## Description
Related to https://github.com/redhat-developer/mapt/pull/422#issuecomment-2728497254

Fix failure in `build-img-ghrunner-test` github action due to oci build target split