### PR TITLE
ci : build oci images on push to `0.8` branch (#420)

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -18,7 +18,7 @@ name: oci-builds
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "0.8" ]
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION
Fix #420 

Trigger oci-builds workflow on push to `0.8` branch.