### PR TITLE
chore: expose param to control increase rate on spot price

### DIFF
--- a/cmd/mapt/cmd/aws/services/kind.go
+++ b/cmd/mapt/cmd/aws/services/kind.go
@@ -42,12 +42,13 @@ func createKind() *cobra.Command {
 			}
 			if err := kind.Create(
 				&maptContext.ContextArgs{
-					ProjectName:   viper.GetString(params.ProjectName),
-					BackedURL:     viper.GetString(params.BackedURL),
-					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
-					Debug:         viper.IsSet(params.Debug),
-					DebugLevel:    viper.GetUint(params.DebugLevel),
-					Tags:          viper.GetStringMapString(params.Tags),
+					ProjectName:           viper.GetString(params.ProjectName),
+					BackedURL:             viper.GetString(params.BackedURL),
+					ResultsOutput:         viper.GetString(params.ConnectionDetailsOutput),
+					Debug:                 viper.IsSet(params.Debug),
+					DebugLevel:            viper.GetUint(params.DebugLevel),
+					SpotPriceIncreaseRate: viper.GetInt(params.SpotPriceIncreaseRate),
+					Tags:                  viper.GetStringMapString(params.Tags),
 				},
 				&kind.KindArgs{
 					InstanceRequest: &instancetypes.AwsInstanceRequest{
@@ -71,6 +72,7 @@ func createKind() *cobra.Command {
 	flagSet.StringP(params.KindK8SVersion, "", "", params.KindK8SVersionDesc)
 	flagSet.StringP(params.LinuxArch, "", params.LinuxArchDefault, params.LinuxArchDesc)
 	flagSet.Bool(awsParams.Spot, false, awsParams.SpotDesc)
+	flagSet.IntP(params.SpotPriceIncreaseRate, "", params.SpotPriceIncreaseRateDefault, params.SpotPriceIncreaseRateDesc)
 	flagSet.StringP(params.Timeout, "", "", params.TimeoutDesc)
 	flagSet.AddFlagSet(params.GetCpusAndMemoryFlagset())
 	flagSet.StringToStringP(params.Tags, "", nil, params.TagsDesc)

--- a/cmd/mapt/cmd/constants/constants.go
+++ b/cmd/mapt/cmd/constants/constants.go
@@ -91,6 +91,11 @@ const (
 	KindCmdDesc        = "Manage a Kind cluster. This is not intended for production use"
 	KindK8SVersion     = "version"
 	KindK8SVersionDesc = "version for k8s offered through Kind."
+
+	// Spot
+	SpotPriceIncreaseRate        = "spot-increase-rate"
+	SpotPriceIncreaseRateDesc    = "Percentage to be added on top of the current calculated spot price to increase chances to get the machine"
+	SpotPriceIncreaseRateDefault = 20
 )
 
 func GetGHActionsFlagset() *pflag.FlagSet {

--- a/pkg/manager/context/context.go
+++ b/pkg/manager/context/context.go
@@ -44,6 +44,8 @@ type ContextArgs struct {
 	// integrations
 	GHRunnerArgs *github.GithubRunnerArgs
 	CirrusPWArgs *cirrus.PersistentWorkerArgs
+	// Spot Bid Safe Limit
+	SpotPriceIncreaseRate int
 }
 
 type context struct {
@@ -55,6 +57,7 @@ type context struct {
 	debugLevel            uint
 	serverless            bool
 	forceDestroy          bool
+	spotPriceIncreaseRate int
 	tags                  map[string]string
 	tagsAsPulumiStringMap pulumi.StringMap
 }
@@ -68,15 +71,16 @@ type Provider interface {
 
 func Init(ca *ContextArgs, provider Provider) error {
 	mc = &context{
-		runID:         CreateRunID(),
-		projectName:   ca.ProjectName,
-		backedURL:     ca.BackedURL,
-		resultsOutput: ca.ResultsOutput,
-		debug:         ca.Debug,
-		debugLevel:    ca.DebugLevel,
-		tags:          ca.Tags,
-		serverless:    ca.Serverless,
-		forceDestroy:  ca.ForceDestroy,
+		runID:                 CreateRunID(),
+		projectName:           ca.ProjectName,
+		backedURL:             ca.BackedURL,
+		resultsOutput:         ca.ResultsOutput,
+		debug:                 ca.Debug,
+		debugLevel:            ca.DebugLevel,
+		tags:                  ca.Tags,
+		serverless:            ca.Serverless,
+		forceDestroy:          ca.ForceDestroy,
+		spotPriceIncreaseRate: ca.SpotPriceIncreaseRate,
 	}
 	addCommonTags()
 	// Init provider
@@ -112,6 +116,8 @@ func DebugLevel() uint { return mc.debugLevel }
 func IsServerless() bool { return mc.serverless }
 
 func IsForceDestroy() bool { return mc.forceDestroy }
+
+func SpotPriceIncreaseRate() int { return mc.spotPriceIncreaseRate }
 
 // It will create a runID
 // if context has been intialized it will set it as the runID for the context

--- a/tkn/infra-aws-kind.yaml
+++ b/tkn/infra-aws-kind.yaml
@@ -92,6 +92,9 @@ spec:
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: 'true'
+    - name: spot-increase-rate
+      description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
+      default: '20'
 
     # OCP params
     - name: version
@@ -168,7 +171,10 @@ spec:
           if [[ $(params.version) != "" ]]; then
             cmd+="--version $(params.version) "
           fi
-          if [[ $(params.spot) == "true" ]]; then cmd+="--spot "; fi
+          if [[ $(params.spot) == "true" ]]; then 
+            cmd+="--spot --spot-increase-rate $(params.spot-increase-rate) " 
+          fi
+
           if [[ $(params.timeout) != "" ]]; then
             cmd+="--timeout $(params.timeout) "
           fi

--- a/tkn/template/infra-aws-kind.yaml
+++ b/tkn/template/infra-aws-kind.yaml
@@ -92,6 +92,9 @@ spec:
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: 'true'
+    - name: spot-increase-rate
+      description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
+      default: '20'
 
     # OCP params
     - name: version
@@ -168,7 +171,10 @@ spec:
           if [[ $(params.version) != "" ]]; then
             cmd+="--version $(params.version) "
           fi
-          if [[ $(params.spot) == "true" ]]; then cmd+="--spot "; fi
+          if [[ $(params.spot) == "true" ]]; then 
+            cmd+="--spot --spot-increase-rate $(params.spot-increase-rate) " 
+          fi
+
           if [[ $(params.timeout) != "" ]]; then
             cmd+="--timeout $(params.timeout) "
           fi


### PR DESCRIPTION
Recently it has been observed when requesting some type of vm sizes thorugh the spot module, even when the placement score is high enough we are not getting those machines, this is mostly due to price conflicts... this commit will introduce a new parameter to set an increase rate to the spot price, so we can increase the overall spot bid

Fix #483 