### PR TITLE
snc: generate ca cert for snc if not provided by user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ out/
 manifest.json
 ami-id
 Pulumi*.yaml
+custom-ca.crt
+custom-ca.key

--- a/cmd/mapt/cmd/aws/services/openshift-snc.go
+++ b/cmd/mapt/cmd/aws/services/openshift-snc.go
@@ -72,9 +72,10 @@ func createSNC() *cobra.Command {
 					Version:        viper.GetString(ocpVersion),
 					Arch:           viper.GetString(params.LinuxArch),
 					PullSecretFile: viper.GetString(pullSecretFile),
-					CaCertFile:     viper.GetString(caCertFile),
-					Spot:           viper.IsSet(awsParams.Spot),
-					Timeout:        viper.GetString(params.Timeout)}); err != nil {
+					CaCertFile: util.If(viper.GetString(caCertFile) == "",
+						util.GenAdminKubeconfigSignerCert(), viper.GetString(caCertFile)),
+					Spot:    viper.IsSet(awsParams.Spot),
+					Timeout: viper.GetString(params.Timeout)}); err != nil {
 				logging.Error(err)
 			}
 			return nil

--- a/pkg/util/ocp_util.go
+++ b/pkg/util/ocp_util.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/redhat-developer/mapt/pkg/util/logging"
+)
+
+func GenAdminKubeconfigSignerCert() string {
+	caCertFileName := "custom-ca.crt"
+	caKeyFileName := "custom-ca.key"
+
+	ca := &x509.Certificate{
+		Subject: pkix.Name{
+			OrganizationalUnit: []string{"openshift"},
+			CommonName:         "admin-kubeconfig-signer-custom",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour * 24 * 365),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	caPrivateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		logging.Error(err)
+		return ""
+	}
+
+	cert, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivateKey.PublicKey, caPrivateKey)
+	if err != nil {
+		logging.Error(err)
+		return ""
+	}
+
+	certPem := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	})
+
+	privateKeyPem := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(caPrivateKey),
+	})
+
+	_ = os.Remove(caCertFileName)
+	_ = os.Remove(caKeyFileName)
+
+	if err := os.WriteFile(caCertFileName, certPem, 0444); err != nil {
+		logging.Error(err)
+		return ""
+	}
+	if err := os.WriteFile(caKeyFileName, privateKeyPem, 0444); err != nil {
+		logging.Error(err)
+		return ""
+	}
+
+	return filepath.Join(".", caCertFileName)
+}


### PR DESCRIPTION
for the openshift-snc service user needs to supply a self signed cert for the admin kubeconfig, this commit adds code to generate this cert when the user has not provided one during create using the flag '--ca-cert-file'