### PR TITLE
openshift-snc: change command checking if kubeconfig is updated

### DIFF
--- a/pkg/provider/aws/action/openshift-snc/constants.go
+++ b/pkg/provider/aws/action/openshift-snc/constants.go
@@ -26,7 +26,7 @@ var (
 	outputDeveloperPass  = "aosDeveloperPass"
 
 	commandReadiness    = "while [ ! -f /tmp/.crc-cluster-ready ]; do sleep 5; done"
-	commandCaServiceRan = "while [ $(sudo systemctl is-active ocp-cluster-ca.service) != inactive ]; do sleep 5; done"
+	commandCaServiceRan = "sudo bash -c 'until oc get node --kubeconfig /opt/kubeconfig --context system:admin; do sleep 5; done'"
 
 	// portHTTP  = 80
 	portHTTPS = 443


### PR DESCRIPTION
the ocp-cluster-ca.service after changing the cluster CA writes a new kubeconfig file with updated client certificates for the system:admin user and the token for kubeadmin user, this changes the command  that checked for the status of the ocp-cluster-ca.service to instead check if the kubeconfig file at /opt/crc/kubeconfig is created

fixes #510 