### PR TITLE
fix: kind: increase pids and inotify

### DIFF
--- a/pkg/provider/util/cloud-config/kind/cloud-config
+++ b/pkg/provider/util/cloud-config/kind/cloud-config
@@ -43,9 +43,12 @@ write_files:
   permissions: '0644'
 runcmd:  
   - dnf install -y podman kubectl
+  - sysctl fs.inotify.max_user_watches=524288
+  - sysctl fs.inotify.max_user_instances=512
   - curl -Lo /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/{{ .KindVersion }}/kind-linux-{{ .Arch }}
   - chmod +x /usr/local/bin/kind
   - kind create cluster --name kind-mapt --config /root/kind-config.yaml --image {{ .KindImage }}
+  - podman update --pids-limit 4096 kind-mapt-control-plane
     # Validate cluster before export the final Kubeconfig
   - cmdKubeconfig="kind get kubeconfig --name kind-mapt > kubeconfig"
   - cmdCheckCluster="kubectl --request-timeout=3s --insecure-skip-tls-verify --kubeconfig kubeconfig get node >/dev/null 2>&1"


### PR DESCRIPTION
# Description

Added extra commands to the kind cloud config

As per recommendation in konflux-ci docs: https://github.com/konflux-ci/konflux-ci?tab=readme-ov-file#bootstrapping-the-cluster

It should fix the issues seen in pods if cluster is under pressure:

```
runtime: failed to create new OS thread (have 14 already; errno=11)
```
and
```
failed to create fsnotify watcher: too many open files
```