### PR TITLE
feat: extra port mapping for kind cluster

### DIFF
--- a/cmd/mapt/cmd/aws/services/kind.go
+++ b/cmd/mapt/cmd/aws/services/kind.go
@@ -49,11 +49,12 @@ func createKind() *cobra.Command {
 					Tags:                  viper.GetStringMapString(params.Tags),
 				},
 				&kind.KindArgs{
-					ComputeRequest: params.GetComputeRequest(),
-					Version:        viper.GetString(params.KindK8SVersion),
-					Arch:           viper.GetString(params.LinuxArch),
-					Spot:           viper.IsSet(awsParams.Spot),
-					Timeout:        viper.GetString(params.Timeout)}); err != nil {
+					ComputeRequest:    params.GetComputeRequest(),
+					Version:           viper.GetString(params.KindK8SVersion),
+					Arch:              viper.GetString(params.LinuxArch),
+					Spot:              viper.IsSet(awsParams.Spot),
+					Timeout:           viper.GetString(params.Timeout),
+					ExtraPortMappings: viper.GetString(params.KindExtraPortMappings)}); err != nil {
 				logging.Error(err)
 			}
 			return nil
@@ -63,6 +64,7 @@ func createKind() *cobra.Command {
 	flagSet.StringP(params.ConnectionDetailsOutput, "", "", params.ConnectionDetailsOutputDesc)
 	flagSet.StringP(params.KindK8SVersion, "", "", params.KindK8SVersionDesc)
 	flagSet.StringP(params.LinuxArch, "", params.LinuxArchDefault, params.LinuxArchDesc)
+	flagSet.StringP(params.KindExtraPortMappings, "", "", params.KindExtraPortMappingsDesc)
 	flagSet.Bool(awsParams.Spot, false, awsParams.SpotDesc)
 	flagSet.IntP(params.SpotPriceIncreaseRate, "", params.SpotPriceIncreaseRateDefault, params.SpotPriceIncreaseRateDesc)
 	flagSet.StringP(params.Timeout, "", "", params.TimeoutDesc)

--- a/cmd/mapt/cmd/params/params.go
+++ b/cmd/mapt/cmd/params/params.go
@@ -101,10 +101,12 @@ const (
 	ForceDestroyDesc string = "if force-destroy is set the command will destroy even if there is a lock."
 
 	// Kind
-	KindCmd            = "kind"
-	KindCmdDesc        = "Manage a Kind cluster. This is not intended for production use"
-	KindK8SVersion     = "version"
-	KindK8SVersionDesc = "version for k8s offered through Kind."
+	KindCmd                   = "kind"
+	KindCmdDesc               = "Manage a Kind cluster. This is not intended for production use"
+	KindK8SVersion            = "version"
+	KindK8SVersionDesc        = "version for k8s offered through Kind."
+	KindExtraPortMappings     = "extra-port-mappings"
+	KindExtraPortMappingsDesc = "Additional port mappings for the Kind cluster. Value should be a JSON array of objects with containerPort, hostPort, and protocol properties. Example: '[{\"containerPort\": 8080, \"hostPort\": 8080, \"protocol\": \"TCP\"}]'"
 
 	// Spot
 	SpotPriceIncreaseRate        = "spot-increase-rate"

--- a/pkg/provider/aws/action/kind/kind.go
+++ b/pkg/provider/aws/action/kind/kind.go
@@ -36,7 +36,7 @@ type KindArgs struct {
 	Arch              string
 	Spot              bool
 	Timeout           string
-	ExtraPortMappings string
+	ExtraPortMappings []kindCloudConfig.PortMapping
 }
 
 type kindRequest struct {
@@ -45,7 +45,7 @@ type kindRequest struct {
 	arch              *string
 	timeout           *string
 	allocationData    *allocation.AllocationData
-	extraPortMappings *string
+	extraPortMappings *[]kindCloudConfig.PortMapping
 }
 
 type KindResultsMetadata struct {
@@ -134,14 +134,9 @@ func (r *kindRequest) deploy(ctx *pulumi.Context) error {
 	}
 
 	// Parse extra port mappings to extract hostPort values
-	extraPortMappingsValue := ""
+	var parsedPortMappings []kindCloudConfig.PortMapping
 	if r.extraPortMappings != nil {
-		extraPortMappingsValue = *r.extraPortMappings
-	}
-
-	parsedPortMappings, err := kindCloudConfig.ParseExtraPortMappings(extraPortMappingsValue)
-	if err != nil {
-		return err
+		parsedPortMappings = *r.extraPortMappings
 	}
 
 	// Extract hostPort values for LB target groups and security group rules

--- a/pkg/provider/util/cloud-config/kind/cloud-config
+++ b/pkg/provider/util/cloud-config/kind/cloud-config
@@ -37,7 +37,10 @@ write_files:
         protocol: TCP
       - containerPort: 30011
         hostPort: 9443
-        protocol: TCP
+        protocol: TCP{{- range .ExtraPortMappings }}
+      - containerPort: {{ .ContainerPort }}
+        hostPort: {{ .HostPort }}
+        protocol: {{ .Protocol }}{{- end }}
   # owner: {{ .Username }}
   path: /root/kind-config.yaml
   permissions: '0644'

--- a/pkg/provider/util/cloud-config/kind/kind_test.go
+++ b/pkg/provider/util/cloud-config/kind/kind_test.go
@@ -1,0 +1,67 @@
+package kind
+
+import (
+	"testing"
+)
+
+func TestParseExtraPortMappings(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []PortMapping
+		wantErr  bool
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []PortMapping{},
+			wantErr:  false,
+		},
+		{
+			name:  "single port mapping",
+			input: `[{"containerPort": 8080, "hostPort": 8080, "protocol": "TCP"}]`,
+			expected: []PortMapping{
+				{ContainerPort: 8080, HostPort: 8080, Protocol: "TCP"},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "multiple port mappings",
+			input: `[{"containerPort": 8080, "hostPort": 8080, "protocol": "TCP"}, {"containerPort": 9090, "hostPort": 9090, "protocol": "UDP"}]`,
+			expected: []PortMapping{
+				{ContainerPort: 8080, HostPort: 8080, Protocol: "TCP"},
+				{ContainerPort: 9090, HostPort: 9090, Protocol: "UDP"},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "invalid JSON",
+			input:    `[{"containerPort": 8080, "hostPort": 8080, "protocol": "TCP"`,
+			expected: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseExtraPortMappings(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseExtraPortMappings() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && len(got) != len(tt.expected) {
+				t.Errorf("ParseExtraPortMappings() got %d port mappings, expected %d", len(got), len(tt.expected))
+				return
+			}
+			for i, mapping := range got {
+				if i < len(tt.expected) {
+					if mapping.ContainerPort != tt.expected[i].ContainerPort ||
+						mapping.HostPort != tt.expected[i].HostPort ||
+						mapping.Protocol != tt.expected[i].Protocol {
+						t.Errorf("ParseExtraPortMappings() got %+v, expected %+v", mapping, tt.expected[i])
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
While testing a konflux running on kind cluster, we found out it'd be good to have additional ports mapped in aws so other services can be publicly accessible (e.g. tekton-results, tekton-pipelines, etc).

This change enables adding extra port mappings via new flag.

Example:
`--extra-port-mappings='[{\"containerPort\": 8080, \"hostPort\": 8080, \"protocol\": \"TCP\"}]'`

### Verification

Ran the `mapt create` command with following param:

```
--extra-port-mappings='[{"containerPort": 30012, "hostPort": 8080, "protocol": "TCP"}, {"containerPort": 30013, "hostPort": 9000, "protocol": "TCP"}]'
```

And verified that the new ports appear in the EC2 inbound rules

<img width="402" height="245" alt="Screenshot 2025-07-15 at 12 07 19" src="https://github.com/user-attachments/assets/7bcc7991-3917-4f3b-94e3-34398ff574f1" />

and that the endpoints are accessible via exposed ports
