### PR TITLE
fix: exclude AZ that are incompatible with EKS

### DIFF
--- a/cmd/mapt/cmd/aws/services/eks.go
+++ b/cmd/mapt/cmd/aws/services/eks.go
@@ -77,6 +77,7 @@ func getCreateEKS() *cobra.Command {
 					Spot:                   viper.IsSet(awsparams.Spot),
 					Addons:                 viper.GetStringSlice(paramAddons),
 					LoadBalancerController: viper.IsSet(paramLoadBalancerController),
+					ExcludedZoneIDs:        viper.GetStringSlice(params.ExcludedZoneIDs),
 				}); err != nil {
 				logging.Error(err)
 			}
@@ -92,6 +93,7 @@ func getCreateEKS() *cobra.Command {
 	flagSet.StringP(paramScalingMinSize, "", defaultScalingMinSize, paramScalingMinSizeDesc)
 	flagSet.StringSliceP(paramAddons, "", []string{}, paramAddonsDesc)
 	flagSet.Bool(paramLoadBalancerController, false, paramLoadBalancerControllerDesc)
+	flagSet.StringSliceP(params.ExcludedZoneIDs, "", []string{}, params.ExcludedZoneIDsDesc)
 	flagSet.AddFlagSet(params.GetCpusAndMemoryFlagset())
 	flagSet.StringP(params.LinuxArch, "", params.LinuxArchDefault, params.LinuxArchDesc)
 	flagSet.Bool(awsparams.Spot, false, awsparams.SpotDesc)

--- a/cmd/mapt/cmd/params/params.go
+++ b/cmd/mapt/cmd/params/params.go
@@ -112,6 +112,10 @@ const (
 	SpotPriceIncreaseRate        = "spot-increase-rate"
 	SpotPriceIncreaseRateDesc    = "Percentage to be added on top of the current calculated spot price to increase chances to get the machine"
 	SpotPriceIncreaseRateDefault = 20
+	
+	// Excluded Zone IDs
+	ExcludedZoneIDs     = "excluded-zone-ids"
+	ExcludedZoneIDsDesc = "Comma-separated list of zone IDs to exclude from availability zone selection"
 )
 
 func GetGHActionsFlagset() *pflag.FlagSet {

--- a/pkg/provider/aws/modules/network/standard/standard.go
+++ b/pkg/provider/aws/modules/network/standard/standard.go
@@ -75,7 +75,7 @@ type NetworkResources struct {
 }
 
 func DefaultNetworkRequest(name, regionName string) NetworkRequest {
-	azs := data.GetAvailabilityZones("")[:3]
+	azs := data.GetAvailabilityZones("", nil)[:3]
 	azCount := len(azs)
 	return NetworkRequest{
 		Name:                name,


### PR DESCRIPTION
Introduces a new flag to exclude specific AWS availability zone IDs when creating EKS clusters. Updates the EKS request and data layer to filter out excluded zone IDs, with sensible defaults for known EKS-incompatible zones. This improves cluster creation reliability by avoiding problematic zones.

Without excluding the AZ, the creation would fail often when creating a cluster with the banned AZ. See https://repost.aws/knowledge-center/eks-cluster-creation-errors

Additionally, fix missing `MCtx` in `NetworkRequest`, causing the EKS cluster creation to fail.