### PR TITLE
fix: AWS new regions not described even when enabled

### DIFF
--- a/pkg/provider/aws/data/regions.go
+++ b/pkg/provider/aws/data/regions.go
@@ -13,6 +13,7 @@ import (
 var (
 	optInStatusFilter      string = "opt-in-status"
 	optInStatusNorRequired string = "opt-in-not-required"
+	optInStatusOptedIn     string = "opted-in"
 )
 
 func GetRegions() ([]string, error) {
@@ -27,7 +28,7 @@ func GetRegions() ([]string, error) {
 			Filters: []ec2Types.Filter{
 				{
 					Name:   &optInStatusFilter,
-					Values: []string{optInStatusNorRequired},
+					Values: []string{optInStatusNorRequired, optInStatusOptedIn},
 				},
 			}})
 	if err != nil {


### PR DESCRIPTION
New regions are not enable by default by AWS, those are considered opted-in regions, and even when enable they need to be explictly asked. This add them on the GetRegions funcion. 

Fix #593