### PR TITLE
fix: debug option is not propagated from Tekton task to mapt

### DIFF
--- a/tkn/infra-aws-fedora.yaml
+++ b/tkn/infra-aws-fedora.yaml
@@ -189,6 +189,11 @@ spec:
         cmd="mapt aws fedora $(params.operation) "
         cmd+="--project-name mapt-fedora-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/fedora/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info " 
           cmd+="--arch $(params.arch) "

--- a/tkn/infra-aws-kind.yaml
+++ b/tkn/infra-aws-kind.yaml
@@ -174,6 +174,11 @@ spec:
         cmd="mapt aws kind $(params.operation) "
         cmd+="--project-name kind-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/kind/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/cluster-info "
           cmd+="--arch $(params.arch) "

--- a/tkn/infra-aws-mac.yaml
+++ b/tkn/infra-aws-mac.yaml
@@ -178,6 +178,10 @@ spec:
         cmd="mapt aws mac $(params.operation) "
         cmd+="--project-name mapt-mac-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/mac/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
         if [[ $(params.only-host) == "true" ]]; then
           cmd+="--only-host "
         fi

--- a/tkn/infra-aws-ocp-snc.yaml
+++ b/tkn/infra-aws-ocp-snc.yaml
@@ -191,6 +191,11 @@ spec:
         cmd="mapt aws ocp-snc $(params.operation) "
         cmd+="--project-name ocp-snc-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/ocp-snc/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/cluster-info "
           cmd+="--arch $(params.arch) "

--- a/tkn/infra-aws-rhel.yaml
+++ b/tkn/infra-aws-rhel.yaml
@@ -216,6 +216,11 @@ spec:
         cmd="mapt aws rhel $(params.operation) "
         cmd+="--project-name mapt-rhel-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/rhel/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info "
           cmd+="--arch $(params.arch) "

--- a/tkn/infra-aws-windows-server.yaml
+++ b/tkn/infra-aws-windows-server.yaml
@@ -182,6 +182,11 @@ spec:
         cmd+="--project-name mapt-windows-$(params.id) "
         # Set the backed url
         cmd+="--backed-url s3://${BUCKET}/mapt/windows/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info "
           cmd+="--ami-name $(params.ami-name) "

--- a/tkn/infra-azure-aks.yaml
+++ b/tkn/infra-azure-aks.yaml
@@ -167,6 +167,11 @@ spec:
         cmd="mapt azure aks $(params.operation) "
         cmd+="--project-name mapt-aks-$(params.id) "
         cmd+="--backed-url azblob://${BLOB}/aks-$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/cluster-info "
           cmd+="--version $(params.k8s-version) "

--- a/tkn/infra-azure-fedora.yaml
+++ b/tkn/infra-azure-fedora.yaml
@@ -178,6 +178,11 @@ spec:
         cmd="mapt azure fedora $(params.operation) "
         cmd+="--project-name mapt-fedora-$(params.id) "
         cmd+="--backed-url azblob://${BLOB}/fedora-$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info "
           cmd+="--arch $(params.arch) --cpus $(params.cpus) "

--- a/tkn/infra-azure-rhel.yaml
+++ b/tkn/infra-azure-rhel.yaml
@@ -182,6 +182,11 @@ spec:
         cmd="mapt azure rhel $(params.operation) "
         cmd+="--project-name mapt-rhel-$(params.id) "
         cmd+="--backed-url azblob://${BLOB}/rhel-$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info "
           cmd+="--arch $(params.arch) --cpus $(params.cpus) "

--- a/tkn/infra-azure-windows-desktop.yaml
+++ b/tkn/infra-azure-windows-desktop.yaml
@@ -181,6 +181,11 @@ spec:
         cmd="mapt azure windows $(params.operation) "
         cmd+="--project-name mapt-windows-$(params.id) "
         cmd+="--backed-url azblob://${BLOB}/windows-$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info "
           cmd+="--windows-featurepack $(params.windows-featurepack) "

--- a/tkn/template/infra-aws-fedora.yaml
+++ b/tkn/template/infra-aws-fedora.yaml
@@ -189,6 +189,11 @@ spec:
         cmd="mapt aws fedora $(params.operation) "
         cmd+="--project-name mapt-fedora-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/fedora/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info " 
           cmd+="--arch $(params.arch) "

--- a/tkn/template/infra-aws-kind.yaml
+++ b/tkn/template/infra-aws-kind.yaml
@@ -174,6 +174,11 @@ spec:
         cmd="mapt aws kind $(params.operation) "
         cmd+="--project-name kind-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/kind/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/cluster-info "
           cmd+="--arch $(params.arch) "

--- a/tkn/template/infra-aws-mac.yaml
+++ b/tkn/template/infra-aws-mac.yaml
@@ -178,6 +178,10 @@ spec:
         cmd="mapt aws mac $(params.operation) "
         cmd+="--project-name mapt-mac-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/mac/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
         if [[ $(params.only-host) == "true" ]]; then
           cmd+="--only-host "
         fi

--- a/tkn/template/infra-aws-ocp-snc.yaml
+++ b/tkn/template/infra-aws-ocp-snc.yaml
@@ -191,6 +191,11 @@ spec:
         cmd="mapt aws ocp-snc $(params.operation) "
         cmd+="--project-name ocp-snc-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/ocp-snc/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/cluster-info "
           cmd+="--arch $(params.arch) "

--- a/tkn/template/infra-aws-rhel.yaml
+++ b/tkn/template/infra-aws-rhel.yaml
@@ -216,6 +216,11 @@ spec:
         cmd="mapt aws rhel $(params.operation) "
         cmd+="--project-name mapt-rhel-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/rhel/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info "
           cmd+="--arch $(params.arch) "

--- a/tkn/template/infra-aws-windows-server.yaml
+++ b/tkn/template/infra-aws-windows-server.yaml
@@ -182,6 +182,11 @@ spec:
         cmd+="--project-name mapt-windows-$(params.id) "
         # Set the backed url
         cmd+="--backed-url s3://${BUCKET}/mapt/windows/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info "
           cmd+="--ami-name $(params.ami-name) "

--- a/tkn/template/infra-azure-aks.yaml
+++ b/tkn/template/infra-azure-aks.yaml
@@ -167,6 +167,11 @@ spec:
         cmd="mapt azure aks $(params.operation) "
         cmd+="--project-name mapt-aks-$(params.id) "
         cmd+="--backed-url azblob://${BLOB}/aks-$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/cluster-info "
           cmd+="--version $(params.k8s-version) "

--- a/tkn/template/infra-azure-fedora.yaml
+++ b/tkn/template/infra-azure-fedora.yaml
@@ -178,6 +178,11 @@ spec:
         cmd="mapt azure fedora $(params.operation) "
         cmd+="--project-name mapt-fedora-$(params.id) "
         cmd+="--backed-url azblob://${BLOB}/fedora-$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info "
           cmd+="--arch $(params.arch) --cpus $(params.cpus) "

--- a/tkn/template/infra-azure-rhel.yaml
+++ b/tkn/template/infra-azure-rhel.yaml
@@ -182,6 +182,11 @@ spec:
         cmd="mapt azure rhel $(params.operation) "
         cmd+="--project-name mapt-rhel-$(params.id) "
         cmd+="--backed-url azblob://${BLOB}/rhel-$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info "
           cmd+="--arch $(params.arch) --cpus $(params.cpus) "

--- a/tkn/template/infra-azure-windows-desktop.yaml
+++ b/tkn/template/infra-azure-windows-desktop.yaml
@@ -181,6 +181,11 @@ spec:
         cmd="mapt azure windows $(params.operation) "
         cmd+="--project-name mapt-windows-$(params.id) "
         cmd+="--backed-url azblob://${BLOB}/windows-$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/host-info "
           cmd+="--windows-featurepack $(params.windows-featurepack) "


### PR DESCRIPTION
debug option affects task's behavior before and after mapt runs but not in mapt itself, resolves #594