### PR TITLE
chore: Allow AWS Shared AMIs at org level

### DIFF
--- a/pkg/provider/aws/data/ami.go
+++ b/pkg/provider/aws/data/ami.go
@@ -58,7 +58,8 @@ func GetAMI(r ImageRequest) (*ImageInfo, error) {
 			Values: []string{*r.BlockDeviceType}})
 	}
 	input := &ec2.DescribeImagesInput{
-		Filters: filters}
+		ExecutableUsers: []string{"self"},
+		Filters:         filters}
 	if r.Owner != nil {
 		input.Owners = []string{*r.Owner}
 	}


### PR DESCRIPTION
This commit includes the Executable users (self) as part of the args when retriving AMIs, this will ensure shared AMIs can be used

Fixes #604 