### PR TITLE
openshift-snc: check for SSH readiness before checking for OCP

### DIFF
--- a/pkg/provider/aws/action/openshift-snc/constants.go
+++ b/pkg/provider/aws/action/openshift-snc/constants.go
@@ -25,7 +25,7 @@ var (
 	outputKubeAdminPass  = "aosKubeAdminPasss"
 	outputDeveloperPass  = "aosDeveloperPass"
 
-	commandReadiness    = "while [ ! -f /tmp/.crc-cluster-ready ]; do sleep 5; done"
+	commandCrcReadiness    = "while [ ! -f /tmp/.crc-cluster-ready ]; do sleep 5; done"
 	commandCaServiceRan = "sudo bash -c 'until oc get node --kubeconfig /opt/kubeconfig --context system:admin || oc get node --kubeconfig /opt/crc/kubeconfig --context system:admin; do sleep 5; done'"
 
 	// portHTTP  = 80


### PR DESCRIPTION
```
INFO  +  command:remote:Command main-ssh-readiness-aos-cmd creating (15s) Dial 1/inf failed: retrying
INFO @ updating..................
INFO  +  command:remote:Command main-ssh-readiness-aos-cmd creating (30s) Dial 2/inf failed: retrying
INFO @ updating...................
INFO  +  command:remote:Command main-ssh-readiness-aos-cmd creating (45s) Dial 3/inf failed: retrying
INFO @ updating..................
INFO  +  command:remote:Command main-ssh-readiness-aos-cmd creating (60s) Dial 4/inf failed: retrying
INFO @ updating..........
INFO  +  command:remote:Command main-ssh-readiness-aos-cmd creating (67s) SSH connectivity established
INFO  +  command:remote:Command main-ssh-readiness-aos-cmd created (67s) SSH connectivity established
INFO  +  command:remote:Command main-ocp-readiness-aos-cmd creating (0s)
```

this makes the split between the SSH connectivity and the OCP readiness clearer.
