### PR TITLE
fix: aws wrong target region on non-spot instances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/redhat-developer/mapt
 
-go 1.24.1
-
-toolchain go1.25.1
+go 1.24.6
 
 require (
 	github.com/coocood/freecache v1.2.4

--- a/pkg/provider/aws/aws.go
+++ b/pkg/provider/aws/aws.go
@@ -32,6 +32,18 @@ func (a *AWS) Init(backedURL string) error {
 	return manageRemoteState(backedURL)
 }
 
+func (a *AWS) DefaultHostingPlace() (*string, error) {
+	hp := os.Getenv("AWS_DEFAULT_REGION")
+	if len(hp) > 0 {
+		return &hp, nil
+	}
+	hp = os.Getenv("AWS_REGION")
+	if len(hp) > 0 {
+		return &hp, nil
+	}
+	return nil, fmt.Errorf("missing default value for AWS Region")
+}
+
 func Provider() *AWS {
 	return &AWS{}
 }

--- a/pkg/provider/aws/data/regions.go
+++ b/pkg/provider/aws/data/regions.go
@@ -12,11 +12,15 @@ import (
 
 var (
 	optInStatusFilter      string = "opt-in-status"
-	optInStatusNorRequired string = "opt-in-not-required"
-	optInStatusOptedIn     string = "opted-in"
+	OptInStatusNotRequired string = "opt-in-not-required"
+	OptInStatusOptedIn     string = "opted-in"
 )
 
 func GetRegions() ([]string, error) {
+	return GetRegionsByOptInStatus([]string{OptInStatusNotRequired, OptInStatusOptedIn})
+}
+
+func GetRegionsByOptInStatus(optInStaus []string) ([]string, error) {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		return nil, err
@@ -28,7 +32,7 @@ func GetRegions() ([]string, error) {
 			Filters: []ec2Types.Filter{
 				{
 					Name:   &optInStatusFilter,
-					Values: []string{optInStatusNorRequired, optInStatusOptedIn},
+					Values: optInStaus,
 				},
 			}})
 	if err != nil {

--- a/pkg/provider/aws/modules/allocation/allocation.go
+++ b/pkg/provider/aws/modules/allocation/allocation.go
@@ -2,7 +2,6 @@ package allocation
 
 import (
 	"fmt"
-	"os"
 
 	mc "github.com/redhat-developer/mapt/pkg/manager/context"
 	cr "github.com/redhat-developer/mapt/pkg/provider/api/compute-request"
@@ -52,7 +51,7 @@ func Allocation(mCtx *mc.Context, args *AllocationArgs) (*AllocationResult, erro
 		}
 		return allocationSpot(mCtx, sr)
 	}
-	return allocationOnDemand(instancesTypes)
+	return allocationOnDemand(mCtx, instancesTypes)
 }
 
 func allocationSpot(mCtx *mc.Context,
@@ -69,8 +68,8 @@ func allocationSpot(mCtx *mc.Context,
 	}, nil
 }
 
-func allocationOnDemand(instancesTypes []string) (*AllocationResult, error) {
-	region := os.Getenv("AWS_DEFAULT_REGION")
+func allocationOnDemand(mCtx *mc.Context, instancesTypes []string) (*AllocationResult, error) {
+	region := mCtx.TargetHostingPlace()
 	excludedAZs := []string{}
 	var err error
 	var az *string

--- a/pkg/provider/azure/azure.go
+++ b/pkg/provider/azure/azure.go
@@ -29,6 +29,10 @@ func (a *Azure) Init(backedURL string) error {
 	return nil
 }
 
+func (a *Azure) DefaultHostingPlace() (*string, error) {
+	return nil, nil
+}
+
 // Envs required for auth with go sdk
 // https://learn.microsoft.com/es-es/azure/developer/go/azure-sdk-authentication?tabs=bash#service-principal-with-a-secret
 // do not match standard envs for pulumi envs for auth with native sdk

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/redhat-developer/mapt/tools
 
-go 1.24.0
-
-toolchain go1.25.1
+go 1.24.6
 
 require github.com/golangci/golangci-lint/v2 v2.5.0
 


### PR DESCRIPTION
When backed url is used with a s3 bucket we need to change the region to match the bucket region, then the original target region was never set it back, causing to always use the bucket region to deploy non spot instances. This commit will set it back. 

Fixes #614 
Fixes #617 