### PR TITLE
Mask AWS and Azure credentials in debug mode

### DIFF
--- a/tkn/infra-aws-fedora.yaml
+++ b/tkn/infra-aws-fedora.yaml
@@ -140,10 +140,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials
+        Warning setting this param to true exposes partially masked credentials
 
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: "false"
 
   results:
@@ -179,16 +179,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ "$(params.debug)" == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ "$(params.debug)" == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ "$(params.operation)" == "create"  ]]; then
           if [[ "$(params.ownerName)" == "" || "$(params.ownerUid)" == "" ]]; then

--- a/tkn/infra-aws-kind.yaml
+++ b/tkn/infra-aws-kind.yaml
@@ -116,10 +116,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
     - name: timeout
       description: The Timeout value is a duration conforming to Go ParseDuration format. This will set a serverless destroy operation based on this.
@@ -152,16 +152,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/infra-aws-mac.yaml
+++ b/tkn/infra-aws-mac.yaml
@@ -116,10 +116,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
 
   results:
@@ -156,16 +156,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/infra-aws-ocp-snc.yaml
+++ b/tkn/infra-aws-ocp-snc.yaml
@@ -131,10 +131,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
     - name: timeout
       description: The Timeout value is a duration conforming to Go ParseDuration format. This will set a serverless destroy operation based on this.
@@ -169,16 +169,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/infra-aws-rhel.yaml
+++ b/tkn/infra-aws-rhel.yaml
@@ -161,10 +161,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials
+        Warning setting this param to true exposes partially masked credentials
 
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: "false"
 
   results:
@@ -203,16 +203,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ "$(params.debug)" == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ "$(params.debug)" == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/infra-aws-windows-server.yaml
+++ b/tkn/infra-aws-windows-server.yaml
@@ -118,10 +118,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
 
   results:
@@ -159,16 +159,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/infra-azure-aks.yaml
+++ b/tkn/infra-azure-aks.yaml
@@ -110,10 +110,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
     
   results:
@@ -142,12 +142,20 @@ spec:
       script: |
         #!/bin/sh
 
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xuo   
-        fi
-        
-        # Credentials
+        set -euo pipefail
+
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export ARM_TENANT_ID=$(cat /opt/az-credentials/tenant_id)
         export ARM_SUBSCRIPTION_ID=$(cat /opt/az-credentials/subscription_id)
         export ARM_CLIENT_ID=$(cat /opt/az-credentials/client_id)
@@ -155,6 +163,18 @@ spec:
         export AZURE_STORAGE_ACCOUNT=$(cat /opt/az-credentials/storage_account)
         export AZURE_STORAGE_KEY=$(cat /opt/az-credentials/storage_key)
         BLOB=$(cat /opt/az-credentials/blob)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "ARM_TENANT_ID=$(mask_credential "$ARM_TENANT_ID")"
+          echo "ARM_SUBSCRIPTION_ID=$(mask_credential "$ARM_SUBSCRIPTION_ID")"
+          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
+          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
+          echo "AZURE_STORAGE_ACCOUNT=$(mask_credential "$AZURE_STORAGE_ACCOUNT")"
+          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
+          echo "BLOB=$BLOB"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/infra-azure-fedora.yaml
+++ b/tkn/infra-azure-fedora.yaml
@@ -132,10 +132,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials
+        Warning setting this param to true exposes partially masked credentials
 
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: "false"
 
   results:
@@ -166,12 +166,20 @@ spec:
       script: |
         #!/bin/sh
 
-        # If debug add verbosity
-        if [[ "$(params.debug)" == "true" ]]; then
-          set -xuo
-        fi
+        set -euo pipefail
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export ARM_TENANT_ID=$(cat /opt/az-credentials/tenant_id)
         export ARM_SUBSCRIPTION_ID=$(cat /opt/az-credentials/subscription_id)
         export ARM_CLIENT_ID=$(cat /opt/az-credentials/client_id)
@@ -179,6 +187,18 @@ spec:
         export AZURE_STORAGE_ACCOUNT=$(cat /opt/az-credentials/storage_account)
         export AZURE_STORAGE_KEY=$(cat /opt/az-credentials/storage_key)
         BLOB=$(cat /opt/az-credentials/blob)
+
+        # If debug add verbosity and print masked credentials
+        if [[ "$(params.debug)" == "true" ]]; then
+          echo "ARM_TENANT_ID=$(mask_credential "$ARM_TENANT_ID")"
+          echo "ARM_SUBSCRIPTION_ID=$(mask_credential "$ARM_SUBSCRIPTION_ID")"
+          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
+          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
+          echo "AZURE_STORAGE_ACCOUNT=$(mask_credential "$AZURE_STORAGE_ACCOUNT")"
+          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
+          echo "BLOB=$BLOB"
+          set -xeuo pipefail
+        fi
 
         if [[ "$(params.operation)" == "create"  ]]; then
           if [[ "$(params.ownerName)" == "" || "$(params.ownerUid)" == "" ]]; then

--- a/tkn/infra-azure-rhel.yaml
+++ b/tkn/infra-azure-rhel.yaml
@@ -136,10 +136,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials
+        Warning setting this param to true exposes partially masked credentials
 
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: "false"
 
   results:
@@ -170,12 +170,20 @@ spec:
       script: |
         #!/bin/sh
 
-        # If debug add verbosity
-        if [[ "$(params.debug)" == "true" ]]; then
-          set -xuo   
-        fi
+        set -euo pipefail
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export ARM_TENANT_ID=$(cat /opt/az-credentials/tenant_id)
         export ARM_SUBSCRIPTION_ID=$(cat /opt/az-credentials/subscription_id)
         export ARM_CLIENT_ID=$(cat /opt/az-credentials/client_id)
@@ -183,6 +191,18 @@ spec:
         export AZURE_STORAGE_ACCOUNT=$(cat /opt/az-credentials/storage_account)
         export AZURE_STORAGE_KEY=$(cat /opt/az-credentials/storage_key)
         BLOB=$(cat /opt/az-credentials/blob)
+
+        # If debug add verbosity and print masked credentials
+        if [[ "$(params.debug)" == "true" ]]; then
+          echo "ARM_TENANT_ID=$(mask_credential "$ARM_TENANT_ID")"
+          echo "ARM_SUBSCRIPTION_ID=$(mask_credential "$ARM_SUBSCRIPTION_ID")"
+          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
+          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
+          echo "AZURE_STORAGE_ACCOUNT=$(mask_credential "$AZURE_STORAGE_ACCOUNT")"
+          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
+          echo "BLOB=$BLOB"
+          set -xeuo pipefail
+        fi
 
         if [[ "$(params.operation)" == "create"  ]]; then
           if [[ "$(params.ownerName)" == "" || "$(params.ownerUid)" == "" ]]; then

--- a/tkn/infra-azure-windows-desktop.yaml
+++ b/tkn/infra-azure-windows-desktop.yaml
@@ -119,10 +119,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
   
   results:
@@ -156,12 +156,20 @@ spec:
       script: |
         #!/bin/sh
 
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xuo   
-        fi
-        
-        # Credentials
+        set -euo pipefail
+
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export ARM_TENANT_ID=$(cat /opt/az-credentials/tenant_id)
         export ARM_SUBSCRIPTION_ID=$(cat /opt/az-credentials/subscription_id)
         export ARM_CLIENT_ID=$(cat /opt/az-credentials/client_id)
@@ -169,6 +177,18 @@ spec:
         export AZURE_STORAGE_ACCOUNT=$(cat /opt/az-credentials/storage_account)
         export AZURE_STORAGE_KEY=$(cat /opt/az-credentials/storage_key)
         BLOB=$(cat /opt/az-credentials/blob)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "ARM_TENANT_ID=$(mask_credential "$ARM_TENANT_ID")"
+          echo "ARM_SUBSCRIPTION_ID=$(mask_credential "$ARM_SUBSCRIPTION_ID")"
+          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
+          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
+          echo "AZURE_STORAGE_ACCOUNT=$(mask_credential "$AZURE_STORAGE_ACCOUNT")"
+          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
+          echo "BLOB=$BLOB"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/template/infra-aws-fedora.yaml
+++ b/tkn/template/infra-aws-fedora.yaml
@@ -140,10 +140,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials
+        Warning setting this param to true exposes partially masked credentials
 
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: "false"
 
   results:
@@ -179,16 +179,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ "$(params.debug)" == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ "$(params.debug)" == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ "$(params.operation)" == "create"  ]]; then
           if [[ "$(params.ownerName)" == "" || "$(params.ownerUid)" == "" ]]; then

--- a/tkn/template/infra-aws-kind.yaml
+++ b/tkn/template/infra-aws-kind.yaml
@@ -116,10 +116,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
     - name: timeout
       description: The Timeout value is a duration conforming to Go ParseDuration format. This will set a serverless destroy operation based on this.
@@ -152,16 +152,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/template/infra-aws-mac.yaml
+++ b/tkn/template/infra-aws-mac.yaml
@@ -116,10 +116,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
 
   results:
@@ -156,16 +156,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/template/infra-aws-ocp-snc.yaml
+++ b/tkn/template/infra-aws-ocp-snc.yaml
@@ -131,10 +131,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
     - name: timeout
       description: The Timeout value is a duration conforming to Go ParseDuration format. This will set a serverless destroy operation based on this.
@@ -169,16 +169,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/template/infra-aws-rhel.yaml
+++ b/tkn/template/infra-aws-rhel.yaml
@@ -161,10 +161,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials
+        Warning setting this param to true exposes partially masked credentials
 
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: "false"
 
   results:
@@ -203,16 +203,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ "$(params.debug)" == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ "$(params.debug)" == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/template/infra-aws-windows-server.yaml
+++ b/tkn/template/infra-aws-windows-server.yaml
@@ -118,10 +118,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
 
   results:
@@ -159,16 +159,32 @@ spec:
         #!/bin/sh
 
         set -euo pipefail
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xeuo pipefail  
-        fi
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
         export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/template/infra-azure-aks.yaml
+++ b/tkn/template/infra-azure-aks.yaml
@@ -110,10 +110,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
     
   results:
@@ -142,12 +142,20 @@ spec:
       script: |
         #!/bin/sh
 
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xuo   
-        fi
-        
-        # Credentials
+        set -euo pipefail
+
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export ARM_TENANT_ID=$(cat /opt/az-credentials/tenant_id)
         export ARM_SUBSCRIPTION_ID=$(cat /opt/az-credentials/subscription_id)
         export ARM_CLIENT_ID=$(cat /opt/az-credentials/client_id)
@@ -155,6 +163,18 @@ spec:
         export AZURE_STORAGE_ACCOUNT=$(cat /opt/az-credentials/storage_account)
         export AZURE_STORAGE_KEY=$(cat /opt/az-credentials/storage_key)
         BLOB=$(cat /opt/az-credentials/blob)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "ARM_TENANT_ID=$(mask_credential "$ARM_TENANT_ID")"
+          echo "ARM_SUBSCRIPTION_ID=$(mask_credential "$ARM_SUBSCRIPTION_ID")"
+          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
+          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
+          echo "AZURE_STORAGE_ACCOUNT=$(mask_credential "$AZURE_STORAGE_ACCOUNT")"
+          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
+          echo "BLOB=$BLOB"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then

--- a/tkn/template/infra-azure-fedora.yaml
+++ b/tkn/template/infra-azure-fedora.yaml
@@ -132,10 +132,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials
+        Warning setting this param to true exposes partially masked credentials
 
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: "false"
 
   results:
@@ -166,12 +166,20 @@ spec:
       script: |
         #!/bin/sh
 
-        # If debug add verbosity
-        if [[ "$(params.debug)" == "true" ]]; then
-          set -xuo
-        fi
+        set -euo pipefail
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export ARM_TENANT_ID=$(cat /opt/az-credentials/tenant_id)
         export ARM_SUBSCRIPTION_ID=$(cat /opt/az-credentials/subscription_id)
         export ARM_CLIENT_ID=$(cat /opt/az-credentials/client_id)
@@ -179,6 +187,18 @@ spec:
         export AZURE_STORAGE_ACCOUNT=$(cat /opt/az-credentials/storage_account)
         export AZURE_STORAGE_KEY=$(cat /opt/az-credentials/storage_key)
         BLOB=$(cat /opt/az-credentials/blob)
+
+        # If debug add verbosity and print masked credentials
+        if [[ "$(params.debug)" == "true" ]]; then
+          echo "ARM_TENANT_ID=$(mask_credential "$ARM_TENANT_ID")"
+          echo "ARM_SUBSCRIPTION_ID=$(mask_credential "$ARM_SUBSCRIPTION_ID")"
+          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
+          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
+          echo "AZURE_STORAGE_ACCOUNT=$(mask_credential "$AZURE_STORAGE_ACCOUNT")"
+          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
+          echo "BLOB=$BLOB"
+          set -xeuo pipefail
+        fi
 
         if [[ "$(params.operation)" == "create"  ]]; then
           if [[ "$(params.ownerName)" == "" || "$(params.ownerUid)" == "" ]]; then

--- a/tkn/template/infra-azure-rhel.yaml
+++ b/tkn/template/infra-azure-rhel.yaml
@@ -136,10 +136,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials
+        Warning setting this param to true exposes partially masked credentials
 
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: "false"
 
   results:
@@ -170,12 +170,20 @@ spec:
       script: |
         #!/bin/sh
 
-        # If debug add verbosity
-        if [[ "$(params.debug)" == "true" ]]; then
-          set -xuo   
-        fi
+        set -euo pipefail
 
-        # Credentials
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export ARM_TENANT_ID=$(cat /opt/az-credentials/tenant_id)
         export ARM_SUBSCRIPTION_ID=$(cat /opt/az-credentials/subscription_id)
         export ARM_CLIENT_ID=$(cat /opt/az-credentials/client_id)
@@ -183,6 +191,18 @@ spec:
         export AZURE_STORAGE_ACCOUNT=$(cat /opt/az-credentials/storage_account)
         export AZURE_STORAGE_KEY=$(cat /opt/az-credentials/storage_key)
         BLOB=$(cat /opt/az-credentials/blob)
+
+        # If debug add verbosity and print masked credentials
+        if [[ "$(params.debug)" == "true" ]]; then
+          echo "ARM_TENANT_ID=$(mask_credential "$ARM_TENANT_ID")"
+          echo "ARM_SUBSCRIPTION_ID=$(mask_credential "$ARM_SUBSCRIPTION_ID")"
+          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
+          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
+          echo "AZURE_STORAGE_ACCOUNT=$(mask_credential "$AZURE_STORAGE_ACCOUNT")"
+          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
+          echo "BLOB=$BLOB"
+          set -xeuo pipefail
+        fi
 
         if [[ "$(params.operation)" == "create"  ]]; then
           if [[ "$(params.ownerName)" == "" || "$(params.ownerUid)" == "" ]]; then

--- a/tkn/template/infra-azure-windows-desktop.yaml
+++ b/tkn/template/infra-azure-windows-desktop.yaml
@@ -119,10 +119,10 @@ spec:
     # Control params
     - name: debug
       description: |
-        Warning setting this param to true expose credentials 
-        
-        The parameter is intended to add verbosity on the task execution and also print credentials on stdout
-        to easily access to remote machice
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
   
   results:
@@ -156,12 +156,20 @@ spec:
       script: |
         #!/bin/sh
 
-        # If debug add verbosity
-        if [[ $(params.debug) == "true" ]]; then
-          set -xuo   
-        fi
-        
-        # Credentials
+        set -euo pipefail
+
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
         export ARM_TENANT_ID=$(cat /opt/az-credentials/tenant_id)
         export ARM_SUBSCRIPTION_ID=$(cat /opt/az-credentials/subscription_id)
         export ARM_CLIENT_ID=$(cat /opt/az-credentials/client_id)
@@ -169,6 +177,18 @@ spec:
         export AZURE_STORAGE_ACCOUNT=$(cat /opt/az-credentials/storage_account)
         export AZURE_STORAGE_KEY=$(cat /opt/az-credentials/storage_key)
         BLOB=$(cat /opt/az-credentials/blob)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "ARM_TENANT_ID=$(mask_credential "$ARM_TENANT_ID")"
+          echo "ARM_SUBSCRIPTION_ID=$(mask_credential "$ARM_SUBSCRIPTION_ID")"
+          echo "ARM_CLIENT_ID=$(mask_credential "$ARM_CLIENT_ID")"
+          echo "ARM_CLIENT_SECRET=$(mask_credential "$ARM_CLIENT_SECRET")"
+          echo "AZURE_STORAGE_ACCOUNT=$(mask_credential "$AZURE_STORAGE_ACCOUNT")"
+          echo "AZURE_STORAGE_KEY=$(mask_credential "$AZURE_STORAGE_KEY")"
+          echo "BLOB=$BLOB"
+          set -xeuo pipefail
+        fi
 
         if [[ $(params.operation) == "create"  ]]; then
           if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then


### PR DESCRIPTION
Previously when debug mode was active, AWS credentials were displayed which is very insecure because Tekton logs could be archived for long time.

Now only the first and last character of sensitive credentials are displayed.