### PR TITLE
feat: Added aws rhelai custom-ami param

### DIFF
--- a/cmd/mapt/cmd/aws/hosts/rhelai.go
+++ b/cmd/mapt/cmd/aws/hosts/rhelai.go
@@ -54,6 +54,7 @@ func getRHELAICreate() *cobra.Command {
 				&rhelai.RHELAIArgs{
 					Prefix:         "main",
 					Version:        viper.GetString(params.RhelAIVersion),
+					CustomAMI:      viper.GetString(params.RhelAIAMICustom),
 					SubsUsername:   viper.GetString(params.SubsUsername),
 					SubsUserpass:   viper.GetString(params.SubsUserpass),
 					ComputeRequest: params.ComputeRequestArgs(),
@@ -66,6 +67,7 @@ func getRHELAICreate() *cobra.Command {
 	flagSet.StringP(params.ConnectionDetailsOutput, "", "", params.ConnectionDetailsOutputDesc)
 	flagSet.StringToStringP(params.Tags, "", nil, params.TagsDesc)
 	flagSet.StringP(params.RhelAIVersion, "", params.RhelAIVersionDefault, params.RhelAIVersionDesc)
+	flagSet.StringP(params.RhelAIAMICustom, "", "", params.RhelAIAMICustomDesc)
 	flagSet.StringP(params.SubsUsername, "", "", params.SubsUsernameDesc)
 	flagSet.StringP(params.SubsUserpass, "", "", params.SubsUserpassDesc)
 	flagSet.StringP(params.Timeout, "", "", params.TimeoutDesc)

--- a/cmd/mapt/cmd/params/params.go
+++ b/cmd/mapt/cmd/params/params.go
@@ -90,6 +90,8 @@ const (
 	RhelAIVersion        string = "version"
 	RhelAIVersionDesc    string = "version for the RHELAI OS"
 	RhelAIVersionDefault string = "1.5.0"
+	RhelAIAMICustom      string = "custom-ami"
+	RhelAIAMICustomDesc  string = "custom AMI to spin RHEL AI OS"
 
 	// Serverless
 	Timeout        string = "timeout"


### PR DESCRIPTION
This param can be used instead of version when creating Unreleased RHEL AI Custom AMIs