### PR TITLE
snc: add command to grow filesystem in user-data

### DIFF
--- a/pkg/provider/aws/action/openshift-snc/cloud-config
+++ b/pkg/provider/aws/action/openshift-snc/cloud-config
@@ -1,10 +1,8 @@
 #cloud-config
-bootcmd:
-  # Resize the partition (4 = /dev/nvme0n1p4 typically)
-  - growpart /dev/nvme0n1 4
-  # Resize the XFS filesystem on /sysroot
-  - xfs_growfs /sysroot
 runcmd:
+  # Resize the XFS filesystem on /sysroot
+  - mount -o remount,rw /sysroot
+  - xfs_growfs /sysroot
   - systemctl enable --now kubelet
   - export PS=$(podman run --rm docker.io/amazon/aws-cli ssm get-parameter --name "{{ .SSMPullSecretName }}" --with-decryption --query "Parameter.Value" --output text)
   - echo ${PS} > /opt/crc/pull-secret


### PR DESCRIPTION
the crc bundle AMI has configured the 'growpart' module of cloud-init to grow the partition, in the 'user-data' provided by 'mapt' we need to extend the filesystem