### PR TITLE
Add full context propagation and proper interrupt handling

### DIFF
--- a/cmd/mapt/cmd/aws/hosts/fedora.go
+++ b/cmd/mapt/cmd/aws/hosts/fedora.go
@@ -48,6 +48,7 @@ func getFedoraCreate() *cobra.Command {
 			}
 			return fedora.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -91,6 +92,7 @@ func getFedoraDestroy() *cobra.Command {
 				return err
 			}
 			return fedora.Destroy(&maptContext.ContextArgs{
+				Context:       cmd.Context(),
 				ProjectName:  viper.GetString(params.ProjectName),
 				BackedURL:    viper.GetString(params.BackedURL),
 				Debug:        viper.IsSet(params.Debug),

--- a/cmd/mapt/cmd/aws/hosts/mac.go
+++ b/cmd/mapt/cmd/aws/hosts/mac.go
@@ -41,6 +41,7 @@ func getMacRequest() *cobra.Command {
 			}
 			return mac.Request(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -81,6 +82,7 @@ func getMacRelease() *cobra.Command {
 			}
 			return mac.Release(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					Debug:      viper.IsSet(params.Debug),
 					DebugLevel: viper.GetUint(params.DebugLevel),
 				},
@@ -107,6 +109,7 @@ func getMacDestroy() *cobra.Command {
 			}
 			return mac.Destroy(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					Debug:        viper.IsSet(params.Debug),
 					DebugLevel:   viper.GetUint(params.DebugLevel),
 					KeepState:    viper.IsSet(params.KeepState),

--- a/cmd/mapt/cmd/aws/hosts/rhel.go
+++ b/cmd/mapt/cmd/aws/hosts/rhel.go
@@ -44,6 +44,7 @@ func getRHELCreate() *cobra.Command {
 			}
 			return rhel.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -94,6 +95,7 @@ func getRHELDestroy() *cobra.Command {
 				return err
 			}
 			return rhel.Destroy(&maptContext.ContextArgs{
+				Context:       cmd.Context(),
 				ProjectName:  viper.GetString(params.ProjectName),
 				BackedURL:    viper.GetString(params.BackedURL),
 				Debug:        viper.IsSet(params.Debug),

--- a/cmd/mapt/cmd/aws/hosts/rhelai.go
+++ b/cmd/mapt/cmd/aws/hosts/rhelai.go
@@ -44,6 +44,7 @@ func getRHELAICreate() *cobra.Command {
 			}
 			return rhelai.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -86,6 +87,7 @@ func getRHELAIDestroy() *cobra.Command {
 				return err
 			}
 			return rhelai.Destroy(&maptContext.ContextArgs{
+				Context:       cmd.Context(),
 				ProjectName:  viper.GetString(params.ProjectName),
 				BackedURL:    viper.GetString(params.BackedURL),
 				Debug:        viper.IsSet(params.Debug),

--- a/cmd/mapt/cmd/aws/hosts/windows.go
+++ b/cmd/mapt/cmd/aws/hosts/windows.go
@@ -57,6 +57,7 @@ func getWindowsCreate() *cobra.Command {
 			}
 			return windows.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -105,6 +106,7 @@ func getWindowsDestroy() *cobra.Command {
 				return err
 			}
 			return windows.Destroy(&maptContext.ContextArgs{
+				Context:       cmd.Context(),
 				ProjectName:  viper.GetString(params.ProjectName),
 				BackedURL:    viper.GetString(params.BackedURL),
 				Debug:        viper.IsSet(params.Debug),

--- a/cmd/mapt/cmd/aws/services/eks.go
+++ b/cmd/mapt/cmd/aws/services/eks.go
@@ -60,6 +60,7 @@ func getCreateEKS() *cobra.Command {
 
 			return awsEKS.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -107,6 +108,7 @@ func getDestroyEKS() *cobra.Command {
 			}
 			return awsEKS.Destroy(
 				&maptContext.ContextArgs{
+					Context:      cmd.Context(),
 					ProjectName:  viper.GetString(params.ProjectName),
 					BackedURL:    viper.GetString(params.BackedURL),
 					Debug:        viper.IsSet(params.Debug),

--- a/cmd/mapt/cmd/aws/services/kind.go
+++ b/cmd/mapt/cmd/aws/services/kind.go
@@ -53,6 +53,7 @@ func createKind() *cobra.Command {
 
 			if _, err := kind.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -94,6 +95,7 @@ func destroyKind() *cobra.Command {
 				return err
 			}
 			return kind.Destroy(&maptContext.ContextArgs{
+				Context:       cmd.Context(),
 				ProjectName:  viper.GetString(params.ProjectName),
 				BackedURL:    viper.GetString(params.BackedURL),
 				Debug:        viper.IsSet(params.Debug),

--- a/cmd/mapt/cmd/aws/services/mac-pool.go
+++ b/cmd/mapt/cmd/aws/services/mac-pool.go
@@ -58,6 +58,7 @@ func createMP() *cobra.Command {
 			}
 			return macpool.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -98,6 +99,7 @@ func destroyMP() *cobra.Command {
 				return err
 			}
 			return macpool.Destroy(&maptContext.ContextArgs{
+				Context:       cmd.Context(),
 				ProjectName:  viper.GetString(params.ProjectName),
 				BackedURL:    viper.GetString(params.BackedURL),
 				Debug:        viper.IsSet(params.Debug),
@@ -123,6 +125,7 @@ func houseKeep() *cobra.Command {
 			}
 			return macpool.HouseKeeper(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName: viper.GetString(params.ProjectName),
 					BackedURL:   viper.GetString(params.BackedURL),
 					Serverless:  viper.IsSet(params.Serverless),
@@ -163,6 +166,7 @@ func request() *cobra.Command {
 			}
 			return macpool.Request(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
 					Debug:         viper.IsSet(params.Debug),
 					DebugLevel:    viper.GetUint(params.DebugLevel),
@@ -201,6 +205,7 @@ func release() *cobra.Command {
 			}
 			return macpool.Release(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					Debug:      viper.IsSet(params.Debug),
 					DebugLevel: viper.GetUint(params.DebugLevel),
 					Serverless: viper.IsSet(params.Serverless),

--- a/cmd/mapt/cmd/aws/services/openshift-snc.go
+++ b/cmd/mapt/cmd/aws/services/openshift-snc.go
@@ -48,6 +48,7 @@ func createSNC() *cobra.Command {
 			}
 			if _, err := openshiftsnc.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -89,6 +90,7 @@ func destroySNC() *cobra.Command {
 				return err
 			}
 			return openshiftsnc.Destroy(&maptContext.ContextArgs{
+				Context:       cmd.Context(),
 				ProjectName:  viper.GetString(params.ProjectName),
 				BackedURL:    viper.GetString(params.BackedURL),
 				Debug:        viper.IsSet(params.Debug),

--- a/cmd/mapt/cmd/azure/hosts/linux.go
+++ b/cmd/mapt/cmd/azure/hosts/linux.go
@@ -52,6 +52,7 @@ func getCreateLinux(ostype data.OSType, defaultOSVersion string) *cobra.Command 
 			}
 			return azureLinux.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -90,13 +91,13 @@ func getDestroyLinux() *cobra.Command {
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err
 			}
-			return azureLinux.Destroy(
-				&maptContext.ContextArgs{
-					ProjectName: viper.GetString(params.ProjectName),
-					BackedURL:   viper.GetString(params.BackedURL),
-					Debug:       viper.IsSet(params.Debug),
-					DebugLevel:  viper.GetUint(params.DebugLevel),
-				})
+			return azureLinux.Destroy(&maptContext.ContextArgs{
+				Context:       cmd.Context(),
+				ProjectName: viper.GetString(params.ProjectName),
+				BackedURL:   viper.GetString(params.BackedURL),
+				Debug:       viper.IsSet(params.Debug),
+				DebugLevel:  viper.GetUint(params.DebugLevel),
+			})
 		},
 	}
 }

--- a/cmd/mapt/cmd/azure/hosts/rhel.go
+++ b/cmd/mapt/cmd/azure/hosts/rhel.go
@@ -41,6 +41,7 @@ func getCreateRHEL() *cobra.Command {
 			}
 			return azureRHEL.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -88,13 +89,13 @@ func getDestroyRHEL() *cobra.Command {
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err
 			}
-			return azureRHEL.Destroy(
-				&maptContext.ContextArgs{
-					ProjectName: viper.GetString(params.ProjectName),
-					BackedURL:   viper.GetString(params.BackedURL),
-					Debug:       viper.IsSet(params.Debug),
-					DebugLevel:  viper.GetUint(params.DebugLevel),
-				})
+			return azureRHEL.Destroy(&maptContext.ContextArgs{
+				Context:       cmd.Context(),
+				ProjectName: viper.GetString(params.ProjectName),
+				BackedURL:   viper.GetString(params.BackedURL),
+				Debug:       viper.IsSet(params.Debug),
+				DebugLevel:  viper.GetUint(params.DebugLevel),
+			})
 		},
 	}
 }

--- a/cmd/mapt/cmd/azure/hosts/windows.go
+++ b/cmd/mapt/cmd/azure/hosts/windows.go
@@ -54,6 +54,7 @@ func getCreateWindowsDesktop() *cobra.Command {
 			}
 			return azureWindows.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -100,13 +101,13 @@ func getDestroyWindowsDesktop() *cobra.Command {
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err
 			}
-			if err := azureWindows.Destroy(
-				&maptContext.ContextArgs{
-					ProjectName: viper.GetString(params.ProjectName),
-					BackedURL:   viper.GetString(params.BackedURL),
-					Debug:       viper.IsSet(params.Debug),
-					DebugLevel:  viper.GetUint(params.DebugLevel),
-				}); err != nil {
+			if err := azureWindows.Destroy(&maptContext.ContextArgs{
+				Context:       cmd.Context(),
+				ProjectName: viper.GetString(params.ProjectName),
+				BackedURL:   viper.GetString(params.BackedURL),
+				Debug:       viper.IsSet(params.Debug),
+				DebugLevel:  viper.GetUint(params.DebugLevel),
+			}); err != nil {
 				logging.Error(err)
 			}
 			return nil

--- a/cmd/mapt/cmd/azure/services/aks.go
+++ b/cmd/mapt/cmd/azure/services/aks.go
@@ -54,6 +54,7 @@ func getCreateAKS() *cobra.Command {
 			}
 			return azureAKS.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -91,13 +92,13 @@ func getDestroyAKS() *cobra.Command {
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err
 			}
-			return azureAKS.Destroy(
-				&maptContext.ContextArgs{
-					ProjectName: viper.GetString(params.ProjectName),
-					BackedURL:   viper.GetString(params.BackedURL),
-					Debug:       viper.IsSet(params.Debug),
-					DebugLevel:  viper.GetUint(params.DebugLevel),
-				})
+			return azureAKS.Destroy(&maptContext.ContextArgs{
+				Context:       cmd.Context(),
+				ProjectName: viper.GetString(params.ProjectName),
+				BackedURL:   viper.GetString(params.BackedURL),
+				Debug:       viper.IsSet(params.Debug),
+				DebugLevel:  viper.GetUint(params.DebugLevel),
+			})
 		},
 	}
 }

--- a/cmd/mapt/cmd/azure/services/kind.go
+++ b/cmd/mapt/cmd/azure/services/kind.go
@@ -54,6 +54,7 @@ func createKind() *cobra.Command {
 
 			if _, err := kind.Create(
 				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
 					ProjectName:   viper.GetString(params.ProjectName),
 					BackedURL:     viper.GetString(params.BackedURL),
 					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
@@ -95,12 +96,13 @@ func destroyKind() *cobra.Command {
 				return err
 			}
 			return kind.Destroy(&maptContext.ContextArgs{
-				ProjectName:  viper.GetString(params.ProjectName),
-				BackedURL:    viper.GetString(params.BackedURL),
-				Debug:        viper.IsSet(params.Debug),
-				DebugLevel:   viper.GetUint(params.DebugLevel),
-				Serverless:   viper.IsSet(params.Serverless),
-				ForceDestroy: viper.IsSet(params.ForceDestroy),
+				Context:       cmd.Context(),
+				ProjectName:   viper.GetString(params.ProjectName),
+				BackedURL:     viper.GetString(params.BackedURL),
+				Debug:         viper.IsSet(params.Debug),
+				DebugLevel:    viper.GetUint(params.DebugLevel),
+				Serverless:    viper.IsSet(params.Serverless),
+				ForceDestroy:  viper.IsSet(params.ForceDestroy),
 			})
 		},
 	}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,7 +1,6 @@
 package manager
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
@@ -34,7 +33,7 @@ func UpStack(c *mc.Context, targetStack Stack, opts ...ManagerOptions) (auto.UpR
 
 func UpStackTargets(mCtx *mc.Context, targetStack Stack, targetURNs []string, opts ...ManagerOptions) (auto.UpResult, error) {
 	logging.Debugf("managing stack %s", targetStack.StackName)
-	ctx := context.Background()
+	ctx := mCtx.Context()
 
 	objectStack, err := getStack(ctx, mCtx, targetStack)
 	if err != nil {
@@ -82,7 +81,7 @@ func UpStackTargets(mCtx *mc.Context, targetStack Stack, targetURNs []string, op
 
 func DestroyStack(mCtx *mc.Context, targetStack Stack, opts ...ManagerOptions) error {
 	logging.Debugf("destroying stack %s", targetStack.StackName)
-	ctx := context.Background()
+	ctx := mCtx.Context()
 
 	objectStack, err := getStack(ctx, mCtx, targetStack)
 	if err != nil {
@@ -133,9 +132,9 @@ func DestroyStack(mCtx *mc.Context, targetStack Stack, opts ...ManagerOptions) e
 	return nil
 }
 
-func CheckStack(target Stack) (*auto.Stack, error) {
+func CheckStack(mCtx *mc.Context, target Stack) (*auto.Stack, error) {
 	logging.Debugf("checking stack %s", target.StackName)
-	stack, err := auto.SelectStackInlineSource(context.Background(), target.StackName,
+	stack, err := auto.SelectStackInlineSource(mCtx.Context(), target.StackName,
 		target.ProjectName, target.DeployFunc, getOpts(target)...)
 	if err != nil {
 		return nil, err
@@ -143,6 +142,6 @@ func CheckStack(target Stack) (*auto.Stack, error) {
 	return &stack, err
 }
 
-func GetOutputs(stack *auto.Stack) (auto.OutputMap, error) {
-	return stack.Outputs(context.Background())
+func GetOutputs(mCtx *mc.Context, stack *auto.Stack) (auto.OutputMap, error) {
+	return stack.Outputs(mCtx.Context())
 }

--- a/pkg/provider/aws/action/eks/eks.go
+++ b/pkg/provider/aws/action/eks/eks.go
@@ -74,6 +74,7 @@ func (r *eksRequest) validate() error {
 
 func Create(mCtxArgs *mc.ContextArgs, args *EKSArgs) (err error) {
 	logging.Debug("Creating EKS")
+	// Create mapt Context
 	mCtx, err := mc.Init(mCtxArgs, aws.Provider())
 	if err != nil {
 		return err
@@ -122,10 +123,10 @@ func Create(mCtxArgs *mc.ContextArgs, args *EKSArgs) (err error) {
 	return r.manageResults(mCtx, sr)
 }
 
-func Destroy(ctx *mc.ContextArgs) error {
-	// Create mapt Context
+func Destroy(mCtxArgs *mc.ContextArgs) error {
 	logging.Debug("Destroy EKS")
-	mCtx, err := mc.Init(ctx, aws.Provider())
+	// Create mapt Context
+	mCtx, err := mc.Init(mCtxArgs, aws.Provider())
 	if err != nil {
 		return err
 	}
@@ -285,7 +286,7 @@ func (r *eksRequest) getAvailabilityZonesForEKS(region string, excludedZoneIDs [
 		// These zone IDs are known to be unsupported by EKS as documented at https://repost.aws/knowledge-center/eks-cluster-creation-errors
 		excludedZoneIDs = []string{"use1-az3", "usw1-az2", "cac1-az3"}
 	}
-	azs := data.GetAvailabilityZones(*r.allocationData.Region, excludedZoneIDs)
+	azs := data.GetAvailabilityZones(r.mCtx.Context(), *r.allocationData.Region, excludedZoneIDs)
 	logging.Debugf("Got availability zones: %v", azs)
 	return azs
 }

--- a/pkg/provider/aws/action/fedora/fedora.go
+++ b/pkg/provider/aws/action/fedora/fedora.go
@@ -71,9 +71,9 @@ func (r *fedoraRequest) validate() error {
 // Create orchestrate 2 stacks:
 // If spot is enable it will run best spot option to get the best option to spin the machine
 // Then it will run the stack for windows dedicated host
-func Create(ctx *mc.ContextArgs, args *FedoraArgs) (err error) {
+func Create(mCtxArgs *mc.ContextArgs, args *FedoraArgs) (err error) {
 	// Create mapt Context
-	mCtx, err := mc.Init(ctx, aws.Provider())
+	mCtx, err := mc.Init(mCtxArgs, aws.Provider())
 	if err != nil {
 		return err
 	}
@@ -108,10 +108,10 @@ func Create(ctx *mc.ContextArgs, args *FedoraArgs) (err error) {
 }
 
 // Will destroy resources related to machine
-func Destroy(c *mc.ContextArgs) (err error) {
+func Destroy(mCtxArgs *mc.ContextArgs) (err error) {
 	logging.Debug("Run fedora destroy")
 	// Create mapt Context
-	mCtx, err := mc.Init(c, aws.Provider())
+	mCtx, err := mc.Init(mCtxArgs, aws.Provider())
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/aws/action/kind/kind.go
+++ b/pkg/provider/aws/action/kind/kind.go
@@ -51,6 +51,7 @@ func (r *kindRequest) validate() error {
 // If spot is enable it will run best spot option to get the best option to spin the machine
 // Then it will run the stack for windows dedicated host
 func Create(mCtxArgs *mc.ContextArgs, args *utilKind.KindArgs) (kr *utilKind.KindResults, err error) {
+	// Create mapt Context
 	mCtx, err := mc.Init(mCtxArgs, aws.Provider())
 	if err != nil {
 		return nil, err
@@ -81,6 +82,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *utilKind.KindArgs) (kr *utilKind.Kin
 
 func Destroy(mCtxArgs *mc.ContextArgs) (err error) {
 	logging.Debug("Run openshift destroy")
+	// Create mapt Context
 	mCtx, err := mc.Init(mCtxArgs, aws.Provider())
 	if err != nil {
 		return err

--- a/pkg/provider/aws/action/mac/mac.go
+++ b/pkg/provider/aws/action/mac/mac.go
@@ -27,9 +27,9 @@ import (
 // create the machine
 //
 //	...
-func Request(ctx *mc.ContextArgs, r *MacRequestArgs) error {
+func Request(mCtxArgs *mc.ContextArgs, r *MacRequestArgs) error {
 	// Create mapt Context
-	mCtx, err := mc.Init(ctx, aws.Provider())
+	mCtx, err := mc.Init(mCtxArgs, aws.Provider())
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func Request(ctx *mc.ContextArgs, r *MacRequestArgs) error {
 	// and replcae (create fresh env)
 	// If for whatever reason the mac has no been created
 	// stack does nt exist pick will require create not replace
-	hi, err := macUtil.PickHost(r.Prefix, his)
+	hi, err := macUtil.PickHost(mCtx, r.Prefix, his)
 	if err != nil {
 		if hi == nil {
 			return err
@@ -61,7 +61,8 @@ func Request(ctx *mc.ContextArgs, r *MacRequestArgs) error {
 		return err
 	}
 	// We update the runID on the dedicated host
-	return tag.Update(mc.TagKeyRunID,
+	return tag.Update(mCtx.Context(),
+		mc.TagKeyRunID,
 		mCtx.RunID(),
 		*hi.Region,
 		*hi.Host.HostId)
@@ -76,7 +77,7 @@ func Request(ctx *mc.ContextArgs, r *MacRequestArgs) error {
 // run release update on it
 func Release(mCtxArgs *mc.ContextArgs, hostID string) error {
 	// Get host as context will be fullfilled with info coming from the tags on the host
-	host, err := data.GetDedicatedHost(hostID)
+	host, err := data.GetDedicatedHost(mCtxArgs.Context, hostID)
 	if err != nil {
 		return err
 	}
@@ -96,7 +97,7 @@ func Release(mCtxArgs *mc.ContextArgs, hostID string) error {
 // If we request destroy mac machine it will look for any machine
 // and check if it is locked if not locked it will destroy it
 func Destroy(mCtxArgs *mc.ContextArgs, hostID string) error {
-	host, err := data.GetDedicatedHost(hostID)
+	host, err := data.GetDedicatedHost(mCtxArgs.Context, hostID)
 	if err != nil {
 		return err
 	}
@@ -110,7 +111,7 @@ func Destroy(mCtxArgs *mc.ContextArgs, hostID string) error {
 	}
 	// Dedicated host is not on a valid state to be deleted
 	// With same backedURL check if machine is locked
-	machineLocked, err := macUtil.IsMachineLocked(hi)
+	machineLocked, err := macUtil.IsMachineLocked(mCtx, hi)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/aws/action/openshift-snc/openshift-snc.go
+++ b/pkg/provider/aws/action/openshift-snc/openshift-snc.go
@@ -1,6 +1,7 @@
 package openshiftsnc
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -108,7 +109,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *OpenshiftSNCArgs) (_ *OpenshiftSncRe
 	}
 	// check if AMI exists
 	amiName := amiName(&args.Version, &args.Arch)
-	if err = checkAMIExists(&amiName, r.allocationData.Region, &args.Arch); err != nil {
+	if err = checkAMIExists(mCtx.Context(), &amiName, r.allocationData.Region, &args.Arch); err != nil {
 		return nil, err
 	}
 	return r.createCluster()
@@ -117,7 +118,6 @@ func Create(mCtxArgs *mc.ContextArgs, args *OpenshiftSNCArgs) (_ *OpenshiftSncRe
 // Will destroy resources related to machine
 func Destroy(mCtxArgs *mc.ContextArgs) (err error) {
 	logging.Debug("Run openshift destroy")
-	// Create mapt Context
 	// Create mapt Context
 	mCtx, err := mc.Init(mCtxArgs, aws.Provider())
 	if err != nil {
@@ -357,8 +357,9 @@ func securityGroups(ctx *pulumi.Context, mCtx *mc.Context, prefix *string,
 	return pulumi.StringArray(sgs[:]), nil
 }
 
-func checkAMIExists(amiName, region, arch *string) error {
+func checkAMIExists(ctx context.Context, amiName, region, arch *string) error {
 	isAMIOffered, _, err := data.IsAMIOffered(
+		ctx,
 		data.ImageRequest{
 			Name:   amiName,
 			Arch:   arch,

--- a/pkg/provider/aws/action/rhel-ai/rhelai.go
+++ b/pkg/provider/aws/action/rhel-ai/rhelai.go
@@ -1,6 +1,7 @@
 package rhelai
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-playground/validator/v10"
@@ -100,7 +101,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *RHELAIArgs) (err error) {
 	if err != nil {
 		return err
 	}
-	if err = checkAMIExists(&amiName, r.allocationData.Region, &amiArch); err != nil {
+	if err = checkAMIExists(mCtx.Context(), &amiName, r.allocationData.Region, &amiArch); err != nil {
 		return err
 	}
 	return r.createMachine()
@@ -271,8 +272,9 @@ func (r *rhelAIRequest) securityGroups(ctx *pulumi.Context, mCtx *mc.Context,
 	return pulumi.StringArray(sgs[:]), nil
 }
 
-func checkAMIExists(amiName, region, arch *string) error {
+func checkAMIExists(ctx context.Context, amiName, region, arch *string) error {
 	isAMIOffered, _, err := data.IsAMIOffered(
+		ctx,
 		data.ImageRequest{
 			Name:   amiName,
 			Arch:   arch,

--- a/pkg/provider/aws/action/windows/windows.go
+++ b/pkg/provider/aws/action/windows/windows.go
@@ -88,7 +88,6 @@ func (r *windowsServerRequest) validate() error {
 // Then it will run the stack for windows dedicated host
 func Create(mCtxArgs *mc.ContextArgs, args *WindowsServerArgs) (err error) {
 	// Create mapt Context
-	// Create mapt Context
 	mCtx, err := mc.Init(mCtxArgs, aws.Provider())
 	if err != nil {
 		return err
@@ -127,6 +126,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *WindowsServerArgs) (err error) {
 		return err
 	}
 	isAMIOffered, _, err := data.IsAMIOffered(
+		mCtx.Context(),
 		data.ImageRequest{
 			Name:   r.amiName,
 			Region: r.allocationData.Region})

--- a/pkg/provider/aws/data/account.go
+++ b/pkg/provider/aws/data/account.go
@@ -6,13 +6,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
-func accountId() (*string, error) {
-	cfg, err := getGlobalConfig()
+func accountId(ctx context.Context) (*string, error) {
+	cfg, err := getGlobalConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 	stsClient := sts.NewFromConfig(cfg)
-	identity, err := stsClient.GetCallerIdentity(context.TODO(), &sts.GetCallerIdentityInput{})
+	identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/aws/data/compute-request.go
+++ b/pkg/provider/aws/data/compute-request.go
@@ -14,27 +14,27 @@ type ComputeSelector struct{}
 func NewComputeSelector() *ComputeSelector { return &ComputeSelector{} }
 
 func (c *ComputeSelector) Select(
-	args *computerequest.ComputeRequestArgs) ([]string, error) {
-	return getInstanceTypes(args)
+	ctx context.Context, args *computerequest.ComputeRequestArgs) ([]string, error) {
+	return getInstanceTypes(ctx, args)
 }
 
-func getInstanceTypes(args *computerequest.ComputeRequestArgs) ([]string, error) {
+func getInstanceTypes(ctx context.Context, args *computerequest.ComputeRequestArgs) ([]string, error) {
 	// if err := validate(r.CPUs, r.MemoryGib, r.Arch); err != nil {
 	// 	return nil, err
 	// }
-	cfg, err := getGlobalConfig()
+	cfg, err := getGlobalConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 	instanceSelector, err := selector.New(
-		context.Background(),
+		ctx,
 		cfg)
 	if err != nil {
 		return nil, err
 	}
 	//nolint:staticcheck // following method is deprecated but no replacement yet
 	instanceTypesSlice, err := instanceSelector.Filter(
-		context.Background(),
+		ctx,
 		filters(args))
 	if err != nil {
 		return nil, err

--- a/pkg/provider/aws/data/ecs.go
+++ b/pkg/provider/aws/data/ecs.go
@@ -9,14 +9,14 @@ import (
 
 var ErrECSClusterNotFound = fmt.Errorf("cluster not found")
 
-func GetCluster(clusterName, region string) (*string, error) {
-	cfg, err := getConfig(region)
+func GetCluster(ctx context.Context, clusterName, region string) (*string, error) {
+	cfg, err := getConfig(ctx, region)
 	if err != nil {
 		return nil, err
 	}
 	client := ecs.NewFromConfig(cfg)
 	listClustersOutput, err := client.ListClusters(
-		context.TODO(),
+		ctx,
 		&ecs.ListClustersInput{})
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func GetCluster(clusterName, region string) (*string, error) {
 		return nil, ErrECSClusterNotFound
 	}
 	cls, err := client.DescribeClusters(
-		context.TODO(),
+		ctx,
 		&ecs.DescribeClustersInput{
 			Clusters: listClustersOutput.ClusterArns,
 		})

--- a/pkg/provider/aws/data/instance-type.go
+++ b/pkg/provider/aws/data/instance-type.go
@@ -22,15 +22,15 @@ type LocationArgs struct {
 // Check if InstanceType is offered on current location
 // it is valid for Regions or Azs
 // if az is nill it will check on region
-func IsInstanceTypeOfferedByLocation(instanceType string, args *LocationArgs) (bool, error) {
-	offerings, err := FilterInstaceTypesOfferedByLocation([]string{instanceType}, args)
+func IsInstanceTypeOfferedByLocation(ctx context.Context, instanceType string, args *LocationArgs) (bool, error) {
+	offerings, err := FilterInstaceTypesOfferedByLocation(ctx, []string{instanceType}, args)
 	return len(offerings) == 1, err
 }
 
 // Get InstanceTypes offerings on current location
 // it is valid for Regions or Azs
-func FilterInstaceTypesOfferedByLocation(instanceTypes []string, args *LocationArgs) ([]string, error) {
-	cfg, err := getConfig(*args.Region)
+func FilterInstaceTypesOfferedByLocation(ctx context.Context, instanceTypes []string, args *LocationArgs) ([]string, error) {
+	cfg, err := getConfig(ctx, *args.Region)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func FilterInstaceTypesOfferedByLocation(instanceTypes []string, args *LocationA
 	}
 	client := ec2.NewFromConfig(cfg)
 	o, err := client.DescribeInstanceTypeOfferings(
-		context.Background(),
+		ctx,
 		&ec2.DescribeInstanceTypeOfferingsInput{
 			LocationType: ec2Types.LocationType(locationType),
 			Filters: []ec2Types.Filter{
@@ -92,9 +92,9 @@ func FilterInstaceTypesOfferedByLocation(instanceTypes []string, args *LocationA
 // }
 
 // Check on all regions which offers the type of instance got one having it
-func LokupRegionOfferingInstanceType(instanceType string) (*string, error) {
+func LokupRegionOfferingInstanceType(ctx context.Context, instanceType string) (*string, error) {
 	// We need to check on all regions
-	regions, err := GetRegions()
+	regions, err := GetRegions(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -103,6 +103,7 @@ func LokupRegionOfferingInstanceType(instanceType string) (*string, error) {
 		lRegion := region
 		go func(c chan string) {
 			if is, err := IsInstanceTypeOfferedByLocation(
+				ctx,
 				instanceType,
 				&LocationArgs{
 					Region: &lRegion,

--- a/pkg/provider/aws/data/instance.go
+++ b/pkg/provider/aws/data/instance.go
@@ -15,19 +15,19 @@ type InstanceResquest struct {
 	Tags map[string]string
 }
 
-func GetInstanceByRegion(r InstanceResquest, regionName string) ([]ec2Types.Instance, error) {
+func GetInstanceByRegion(ctx context.Context, r InstanceResquest, regionName string) ([]ec2Types.Instance, error) {
 	var cfgOpts config.LoadOptionsFunc
 	if len(regionName) > 0 {
 		cfgOpts = config.WithRegion(regionName)
 	}
-	cfg, err := config.LoadDefaultConfig(context.Background(), cfgOpts)
+	cfg, err := config.LoadDefaultConfig(ctx, cfgOpts)
 	if err != nil {
 		return nil, err
 	}
 	client := ec2.NewFromConfig(cfg)
 	tagKey := "tag-key"
 	i, err := client.DescribeInstances(
-		context.Background(),
+		ctx,
 		&ec2.DescribeInstancesInput{
 			Filters: []ec2Types.Filter{
 				{

--- a/pkg/provider/aws/data/regions.go
+++ b/pkg/provider/aws/data/regions.go
@@ -16,18 +16,18 @@ var (
 	OptInStatusOptedIn     string = "opted-in"
 )
 
-func GetRegions() ([]string, error) {
-	return GetRegionsByOptInStatus([]string{OptInStatusNotRequired, OptInStatusOptedIn})
+func GetRegions(ctx context.Context) ([]string, error) {
+	return GetRegionsByOptInStatus(ctx, []string{OptInStatusNotRequired, OptInStatusOptedIn})
 }
 
-func GetRegionsByOptInStatus(optInStaus []string) ([]string, error) {
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+func GetRegionsByOptInStatus(ctx context.Context, optInStaus []string) ([]string, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 	client := ec2.NewFromConfig(cfg)
 	regions, err := client.DescribeRegions(
-		context.Background(),
+		ctx,
 		&ec2.DescribeRegionsInput{
 			Filters: []ec2Types.Filter{
 				{

--- a/pkg/provider/aws/data/role.go
+++ b/pkg/provider/aws/data/role.go
@@ -7,14 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 )
 
-func GetRole(roleName string) (*string, error) {
-	cfg, err := getGlobalConfig()
+func GetRole(ctx context.Context, roleName string) (*string, error) {
+	cfg, err := getGlobalConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 	client := iam.NewFromConfig(cfg)
 	roleOutput, err := client.GetRole(
-		context.TODO(), &iam.GetRoleInput{
+		ctx, &iam.GetRoleInput{
 			RoleName: aws.String(roleName),
 		})
 	if err != nil {

--- a/pkg/provider/aws/data/s3.go
+++ b/pkg/provider/aws/data/s3.go
@@ -16,16 +16,16 @@ const (
 
 func ValidateS3Path(p string) bool { return strings.HasPrefix(p, s3Prefix) }
 
-func GetBucketLocationFromS3Path(p string) (*string, error) {
+func GetBucketLocationFromS3Path(ctx context.Context, p string) (*string, error) {
 	bucket, err := getBucketFromS3Path(p)
 	if err != nil {
 		return nil, err
 	}
-	return GetBucketLocation(*bucket)
+	return GetBucketLocation(ctx, *bucket)
 }
 
-func GetBucketLocation(bucketName string) (*string, error) {
-	cfg, err := getGlobalConfig()
+func GetBucketLocation(ctx context.Context, bucketName string) (*string, error) {
+	cfg, err := getGlobalConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func GetBucketLocation(bucketName string) (*string, error) {
 	// 		Bucket: &bucketName,
 	// 	})
 	b, err := client.GetBucketLocation(
-		context.Background(),
+		ctx,
 		&s3.GetBucketLocationInput{
 			Bucket: &bucketName,
 		})

--- a/pkg/provider/aws/data/util.go
+++ b/pkg/provider/aws/data/util.go
@@ -22,15 +22,15 @@ func allTagsMatches(tags map[string]string, tTags []ec2Types.Tag) bool {
 	return count == len(tags)
 }
 
-func getGlobalConfig() (aws.Config, error) {
-	return getConfig("")
+func getGlobalConfig(ctx context.Context) (aws.Config, error) {
+	return getConfig(ctx, "")
 }
 
-func getConfig(region string) (aws.Config, error) {
+func getConfig(ctx context.Context, region string) (aws.Config, error) {
 	if len(region) > 0 {
 		return config.LoadDefaultConfig(
-			context.Background(),
+			ctx,
 			config.WithRegion(region))
 	}
-	return config.LoadDefaultConfig(context.Background())
+	return config.LoadDefaultConfig(ctx)
 }

--- a/pkg/provider/aws/modules/allocation/allocation.go
+++ b/pkg/provider/aws/modules/allocation/allocation.go
@@ -32,7 +32,7 @@ func Allocation(mCtx *mc.Context, args *AllocationArgs) (*AllocationResult, erro
 	instancesTypes := args.ComputeRequest.ComputeSizes
 	if len(instancesTypes) == 0 {
 		instancesTypes, err =
-			data.NewComputeSelector().Select(args.ComputeRequest)
+			data.NewComputeSelector().Select(mCtx.Context(), args.ComputeRequest)
 		if err != nil {
 			return nil, err
 		}
@@ -74,14 +74,14 @@ func allocationOnDemand(mCtx *mc.Context, instancesTypes []string) (*AllocationR
 	var err error
 	var az *string
 	var supportedInstancesType []string
-	azs := data.GetAvailabilityZones(region, nil)
+	azs := data.GetAvailabilityZones(mCtx.Context(), region, nil)
 	for {
-		az, err = data.GetRandomAvailabilityZone(region, excludedAZs)
+		az, err = data.GetRandomAvailabilityZone(mCtx.Context(), region, excludedAZs)
 		if err != nil {
 			return nil, err
 		}
 		supportedInstancesType, err =
-			data.FilterInstaceTypesOfferedByLocation(instancesTypes, &data.LocationArgs{
+			data.FilterInstaceTypesOfferedByLocation(mCtx.Context(), instancesTypes, &data.LocationArgs{
 				Region: &region,
 				Az:     az,
 			})

--- a/pkg/provider/aws/modules/ami/ami.go
+++ b/pkg/provider/aws/modules/ami/ami.go
@@ -57,7 +57,7 @@ func DestroyReplica(mCtxArgs *mc.ContextArgs) (err error) {
 }
 
 func manageReplica(r *replicateRequest, operation string) (err error) {
-	regions, err := data.GetRegions()
+	regions, err := data.GetRegions(r.mCtx.Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/aws/modules/ami/stack.go
+++ b/pkg/provider/aws/modules/ami/stack.go
@@ -40,7 +40,7 @@ func (r CopyAMIRequest) Create() error {
 	if err := r.validate(); err != nil {
 		return err
 	}
-	_, err := manager.CheckStack(manager.Stack{
+	_, err := manager.CheckStack(r.MCtx,manager.Stack{
 		StackName:   r.MCtx.StackNameByProject("copyAMI"),
 		ProjectName: r.MCtx.ProjectName(),
 		BackedURL:   r.MCtx.BackedURL()})
@@ -52,7 +52,7 @@ func (r CopyAMIRequest) Create() error {
 
 // Check if spot option stack was created on the backed url
 func Exist(mCtx *mc.Context) bool {
-	s, err := manager.CheckStack(manager.Stack{
+	s, err := manager.CheckStack(mCtx, manager.Stack{
 		StackName:   mCtx.StackNameByProject("copyAMI"),
 		ProjectName: mCtx.ProjectName(),
 		BackedURL:   mCtx.BackedURL()})
@@ -92,7 +92,7 @@ func (r CopyAMIRequest) createStack(mCtx *mc.Context) error {
 // and it will export the data from the best spot option to the stack state
 func (r CopyAMIRequest) deployer(ctx *pulumi.Context) error {
 	// find were the ami is
-	amiInfo, err := data.FindAMI(r.AMISourceName, r.AMISourceArch)
+	amiInfo, err := data.FindAMI(r.MCtx.Context(), r.AMISourceName, r.AMISourceArch)
 	if err != nil {
 		return err
 	}
@@ -116,6 +116,7 @@ func (r CopyAMIRequest) deployer(ctx *pulumi.Context) error {
 		if r.FastLaunch {
 			_ = ami.ID().ApplyT(func(amiID string) error {
 				return amiSVC.EnableFastLaunch(
+					r.MCtx.Context(),
 					r.AMITargetRegion,
 					&amiID,
 					&r.MaxParallel)

--- a/pkg/provider/aws/modules/mac/host/host.go
+++ b/pkg/provider/aws/modules/mac/host/host.go
@@ -60,12 +60,12 @@ func createDedicatedHost(mCtx *mc.Context, args *MacDedicatedHostRequestArgs,
 		arch:   args.Architecture,
 		tags:   tags,
 	}
-	dHArgs.region, err = getRegion(args.Architecture, args.FixedLocation)
+	dHArgs.region, err = getRegion(mCtx.Context(), args.Architecture, args.FixedLocation)
 	if err != nil {
 		return nil, err
 	}
 	// pick random az from region ensuring machine is offered (sometimes machines are not offered on each az from a region)
-	dHArgs.availabilityZone, err = getAZ(*dHArgs.region, args.Architecture)
+	dHArgs.availabilityZone, err = getAZ(mCtx.Context(), *dHArgs.region, args.Architecture)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func createDedicatedHost(mCtx *mc.Context, args *MacDedicatedHostRequestArgs,
 		return nil, err
 	}
 	logging.Debugf("mac dedicated host with host id %s has been created successfully", *dhID)
-	host, err := data.GetDedicatedHost(*dhID)
+	host, err := data.GetDedicatedHost(mCtx.Context(), *dhID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/aws/modules/network/standard/standard.go
+++ b/pkg/provider/aws/modules/network/standard/standard.go
@@ -1,6 +1,7 @@
 package standard
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-playground/validator/v10"
@@ -83,8 +84,8 @@ type NetworkResources struct {
 	IntraSNResources   []*subnet.PrivateSubnetResources
 }
 
-func DefaultNetworkRequest(name, regionName string) NetworkRequest {
-	azs := data.GetAvailabilityZones("", nil)[:3]
+func DefaultNetworkRequest(ctx context.Context, name, regionName string) NetworkRequest {
+	azs := data.GetAvailabilityZones(ctx, "", nil)[:3]
 	azCount := len(azs)
 	return NetworkRequest{
 		Name:                name,

--- a/pkg/provider/aws/modules/serverless/serverless.go
+++ b/pkg/provider/aws/modules/serverless/serverless.go
@@ -120,7 +120,7 @@ func (r *serverlessRequest) deploy(ctx *pulumi.Context) error {
 	if err != nil {
 		return err
 	}
-	subnetID, err := data.GetRandomPublicSubnet(r.region)
+	subnetID, err := data.GetRandomPublicSubnet(r.mCtx.Context(), r.region)
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func (r *serverlessRequest) deploy(ctx *pulumi.Context) error {
 // it exists it will pick the cluster otherwise it will create and will not be deleted
 func getClusterArn(ctx *pulumi.Context, mCtx *mc.Context, region, prefix, componentID string) (*pulumi.StringOutput, error) {
 	clusterName := fmt.Sprintf("%s-%s", maptServerlessDefaultPrefix, "cluster")
-	clusterArn, err := data.GetCluster(clusterName, region)
+	clusterArn, err := data.GetCluster(mCtx.Context(), clusterName, region)
 	if err != nil {
 		if err == data.ErrECSClusterNotFound {
 			if cluster, err := ecs.NewCluster(ctx,
@@ -188,7 +188,7 @@ func getClusterArn(ctx *pulumi.Context, mCtx *mc.Context, region, prefix, compon
 // it exists it will pick the role otherwise it will create and will not be deleted
 func getTaskRole(ctx *pulumi.Context, mCtx *mc.Context, prefix, componentID string) (*pulumi.StringOutput, error) {
 	roleName := fmt.Sprintf("%s-%s", maptServerlessDefaultPrefix, "role")
-	roleArn, err := data.GetRole(roleName)
+	roleArn, err := data.GetRole(mCtx.Context(), roleName)
 	if err != nil {
 		if role, err := createTaskRole(ctx, mCtx, roleName, prefix, componentID); err != nil {
 			return nil, err
@@ -269,7 +269,7 @@ func createTaskRole(ctx *pulumi.Context, mCtx *mc.Context, roleName, prefix, com
 // it exists it will pick the role otherwise it will create and will not be deleted
 func getSchedulerRole(ctx *pulumi.Context, mCtx *mc.Context, prefix, componentID string) (*pulumi.StringOutput, error) {
 	roleName := fmt.Sprintf("%s-%s", maptServerlessDefaultPrefix, "sch-role")
-	roleArn, err := data.GetRole(roleName)
+	roleArn, err := data.GetRole(mCtx.Context(), roleName)
 	if err != nil {
 		if role, err := createSchedulerRole(ctx, mCtx, roleName, prefix, componentID); err != nil {
 			return nil, err

--- a/pkg/provider/aws/modules/spot/stack.go
+++ b/pkg/provider/aws/modules/spot/stack.go
@@ -70,7 +70,7 @@ func Create(mCtx *mc.Context, args *SpotStackArgs) (*SpotStackResult, error) {
 	if err := args.validate(); err != nil {
 		return nil, err
 	}
-	stack, err := manager.CheckStack(manager.Stack{
+	stack, err := manager.CheckStack(mCtx, manager.Stack{
 		StackName:   mCtx.StackNameByProject("spotOption"),
 		ProjectName: mCtx.ProjectName(),
 		BackedURL:   mCtx.BackedURL()})
@@ -78,13 +78,13 @@ func Create(mCtx *mc.Context, args *SpotStackArgs) (*SpotStackResult, error) {
 	if err != nil {
 		return r.createStack()
 	} else {
-		return getOutputs(stack)
+		return getOutputs(mCtx, stack)
 	}
 }
 
 // Check if spot option stack was created on the backed url
 func Exist(mCtx *mc.Context) bool {
-	s, err := manager.CheckStack(manager.Stack{
+	s, err := manager.CheckStack(mCtx, manager.Stack{
 		StackName:   mCtx.StackNameByProject("spotOption"),
 		ProjectName: mCtx.ProjectName(),
 		BackedURL:   mCtx.BackedURL()})
@@ -152,8 +152,8 @@ func (r *spotStackRequest) deployer(ctx *pulumi.Context) error {
 }
 
 // function to get outputs from an existing stack
-func getOutputs(stack *auto.Stack) (*SpotStackResult, error) {
-	outputs, err := manager.GetOutputs(stack)
+func getOutputs(mCtx *mc.Context, stack *auto.Stack) (*SpotStackResult, error) {
+	outputs, err := manager.GetOutputs(mCtx, stack)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/aws/services/ec2/ami/ami.go
+++ b/pkg/provider/aws/services/ec2/ami/ami.go
@@ -49,18 +49,18 @@ func GetAMIByName(ctx *pulumi.Context,
 }
 
 // Enable Fast Launchon AMI, it will only work with Windows instances
-func EnableFastLaunch(region *string, amiID *string, maxParallel *int32) error {
+func EnableFastLaunch(ctx context.Context, region *string, amiID *string, maxParallel *int32) error {
 	logging.Debugf("Enabling fast launch for ami %s", *amiID)
 	var cfgOpts config.LoadOptionsFunc
 	if len(*region) > 0 {
 		cfgOpts = config.WithRegion(*region)
 	}
-	cfg, err := config.LoadDefaultConfig(context.TODO(), cfgOpts)
+	cfg, err := config.LoadDefaultConfig(ctx, cfgOpts)
 	if err != nil {
 		return err
 	}
 	client := awsEC2.NewFromConfig(cfg)
-	o, err := client.EnableFastLaunch(context.Background(),
+	o, err := client.EnableFastLaunch(ctx,
 		&awsEC2.EnableFastLaunchInput{
 			ImageId:             amiID,
 			MaxParallelLaunches: maxParallel,
@@ -71,7 +71,7 @@ func EnableFastLaunch(region *string, amiID *string, maxParallel *int32) error {
 	fastLaunchState := o.State
 	for fastLaunchState != awsEC2Types.FastLaunchStateCodeEnabled {
 		dfl, err := client.DescribeFastLaunchImages(
-			context.Background(),
+			ctx,
 			&awsEC2.DescribeFastLaunchImagesInput{
 				ImageIds: []string{*amiID},
 			})

--- a/pkg/provider/aws/services/ec2/compute/compute.go
+++ b/pkg/provider/aws/services/ec2/compute/compute.go
@@ -20,8 +20,7 @@ type ReplaceRootVolumeRequest struct {
 // and will delete the replaced volume
 // If wait flag is true on request the funcion will wait until the replace task succeed
 // otherwise it will trigger the task and return the id to reference it
-func ReplaceRootVolume(r ReplaceRootVolumeRequest) (*string, error) {
-	ctx := context.Background()
+func ReplaceRootVolume(ctx context.Context, r ReplaceRootVolumeRequest) (*string, error) {
 	cfg, err := config.LoadDefaultConfig(
 		ctx,
 		config.WithRegion(r.Region))

--- a/pkg/provider/aws/services/tag/tag.go
+++ b/pkg/provider/aws/services/tag/tag.go
@@ -8,9 +8,8 @@ import (
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
-func Update(tagKey, tagValue, region, resourceID string) error {
+func Update(ctx context.Context, tagKey, tagValue, region, resourceID string) error {
 	var cfgOpts config.LoadOptionsFunc
-	ctx := context.Background()
 	if len(region) > 0 {
 		cfgOpts = config.WithRegion(region)
 	}

--- a/pkg/provider/azure/action/aks/aks.go
+++ b/pkg/provider/azure/action/aks/aks.go
@@ -57,8 +57,8 @@ func (r *aksRequest) validate() error {
 }
 
 func Create(mCtxArgs *mc.ContextArgs, args *AKSArgs) (err error) {
-	// Create mapt Context
 	logging.Debug("Creating AKS")
+	// Create mapt Context
 	mCtx, err := mc.Init(mCtxArgs, azure.Provider())
 	if err != nil {
 		return err
@@ -86,8 +86,8 @@ func Create(mCtxArgs *mc.ContextArgs, args *AKSArgs) (err error) {
 }
 
 func Destroy(mCtxArgs *mc.ContextArgs) error {
-	// Create mapt Context
 	logging.Debug("Destroy AKS")
+	// Create mapt Context
 	mCtx, err := mc.Init(mCtxArgs, azure.Provider())
 	if err != nil {
 		return err

--- a/pkg/provider/azure/action/rhel/rhel.go
+++ b/pkg/provider/azure/action/rhel/rhel.go
@@ -24,7 +24,7 @@ type RhelArgs struct {
 	Spot           *spotTypes.SpotArgs
 }
 
-func Create(ctx *maptContext.ContextArgs, r *RhelArgs) (err error) {
+func Create(mCtxArgs *maptContext.ContextArgs, r *RhelArgs) (err error) {
 	logging.Debug("Creating RHEL Server")
 	rhelCloudConfig := &rhelApi.CloudConfigArgs{
 		SNCProfile:   r.ProfileSNC,
@@ -44,9 +44,9 @@ func Create(ctx *maptContext.ContextArgs, r *RhelArgs) (err error) {
 			// As RHEL now is set with cloud init this is the ReadinessCommand to check
 			CloudConfigAsUserData: rhelCloudConfig,
 			ReadinessCommand:      command.CommandCloudInitWait}
-	return azureLinux.Create(ctx, azureLinuxRequest)
+	return azureLinux.Create(mCtxArgs, azureLinuxRequest)
 }
 
-func Destroy(ctx *maptContext.ContextArgs) error {
-	return azureLinux.Destroy(ctx)
+func Destroy(mCtxArgs *maptContext.ContextArgs) error {
+	return azureLinux.Destroy(mCtxArgs)
 }

--- a/pkg/provider/azure/azure.go
+++ b/pkg/provider/azure/azure.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"context"
 	"os"
 	"slices"
 	"strings"
@@ -24,7 +25,7 @@ func Provider() *Azure {
 	return &Azure{}
 }
 
-func (a *Azure) Init(backedURL string) error {
+func (a *Azure) Init(ctx context.Context, backedURL string) error {
 	setAZIdentityEnvs()
 	return nil
 }

--- a/pkg/provider/azure/data/location.go
+++ b/pkg/provider/azure/data/location.go
@@ -10,12 +10,11 @@ import (
 	"github.com/redhat-developer/mapt/pkg/util"
 )
 
-func Locations() ([]string, error) {
+func Locations(ctx context.Context) ([]string, error) {
 	cred, subscriptionID, err := getCredentials()
 	if err != nil {
 		return nil, err
 	}
-	ctx := context.Background()
 	client, err := armsubscriptions.NewClient(cred, nil)
 	if err != nil {
 		return nil, err
@@ -34,7 +33,7 @@ func Locations() ([]string, error) {
 	return locations, nil
 }
 
-func LocationsBySupportedResourceType(rt ResourceType) ([]string, error) {
+func LocationsBySupportedResourceType(ctx context.Context, rt ResourceType) ([]string, error) {
 	cred, subscriptionID, err := getCredentials()
 	if err != nil {
 		return nil, err
@@ -43,7 +42,7 @@ func LocationsBySupportedResourceType(rt ResourceType) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Get(context.Background(), "Microsoft.Network", nil)
+	resp, err := client.Get(ctx, "Microsoft.Network", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -55,10 +54,10 @@ func LocationsBySupportedResourceType(rt ResourceType) ([]string, error) {
 			}
 		}
 	}
-	return translate(cred, subscriptionID, locationsDN)
+	return translate(ctx, cred, subscriptionID, locationsDN)
 }
 
-func translate(cred *azidentity.DefaultAzureCredential,
+func translate(ctx context.Context, cred *azidentity.DefaultAzureCredential,
 	subscriptionID *string, lDisplayName []string) ([]string, error) {
 	locationsClient, err := armsubscriptions.NewClient(cred, nil)
 	if err != nil {
@@ -67,7 +66,7 @@ func translate(cred *azidentity.DefaultAzureCredential,
 	locationPager := locationsClient.NewListLocationsPager(*subscriptionID, nil)
 	var locationsMap = make(map[string]string)
 	for locationPager.More() {
-		page, err := locationPager.NextPage(context.Background())
+		page, err := locationPager.NextPage(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/azure/data/vmsize.go
+++ b/pkg/provider/azure/data/vmsize.go
@@ -10,19 +10,18 @@ import (
 	"github.com/redhat-developer/mapt/pkg/util"
 )
 
-func IsVMSizeOfferedByLocation(vmSize, location string) (bool, error) {
-	offerings, err := FilterVMSizeOfferedByLocation([]string{vmSize}, location)
+func IsVMSizeOfferedByLocation(ctx context.Context, vmSize, location string) (bool, error) {
+	offerings, err := FilterVMSizeOfferedByLocation(ctx, []string{vmSize}, location)
 	return len(offerings) == 1, err
 }
 
 // Get InstanceTypes offerings on current location
-func FilterVMSizeOfferedByLocation(vmSizes []string, location string) ([]string, error) {
+func FilterVMSizeOfferedByLocation(ctx context.Context, vmSizes []string, location string) ([]string, error) {
 	// Create a new Azure credential (uses environment variables or managed identity)
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, err
 	}
-	ctx := context.Background()
 	subscriptionId := os.Getenv("AZURE_SUBSCRIPTION_ID")
 	clientFactory, err := armcompute.NewClientFactory(subscriptionId, cred, nil)
 	if err != nil {

--- a/pkg/provider/azure/modules/allocation/allocation.go
+++ b/pkg/provider/azure/modules/allocation/allocation.go
@@ -27,7 +27,7 @@ func Allocation(mCtx *mc.Context, args *AllocationArgs) (*AllocationResult, erro
 	computeSizes := args.ComputeRequest.ComputeSizes
 	if len(computeSizes) == 0 {
 		computeSizes, err =
-			data.NewComputeSelector().Select(args.ComputeRequest)
+			data.NewComputeSelector().Select(mCtx.Context(), args.ComputeRequest)
 		if err != nil {
 			return nil, err
 		}
@@ -57,7 +57,7 @@ func Allocation(mCtx *mc.Context, args *AllocationArgs) (*AllocationResult, erro
 	} else {
 		// Filter for current location the computesizes
 		supportedComputeSizes, err := data.FilterComputeSizesByLocation(
-			args.Location, computeSizes)
+			mCtx.Context(), args.Location, computeSizes)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/azure/modules/virtual-machine/virtual-machine.go
+++ b/pkg/provider/azure/modules/virtual-machine/virtual-machine.go
@@ -52,7 +52,7 @@ func Create(ctx *pulumi.Context, mCtx *mc.Context, args *VirtualMachineArgs) (Vi
 		imageReferenceArgs = compute.ImageReferenceArgs{
 			CommunityGalleryImageId: pulumi.String(args.ImageID)}
 	} else {
-		finalSku, err := data.SkuG2Support(args.Location, args.Publisher, args.Offer, args.Sku)
+		finalSku, err := data.SkuG2Support(mCtx.Context(), args.Location, args.Publisher, args.Offer, args.Sku)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This MR adds full context propagation to MAPT so that interrupts (**SIGINT/SIGTERM**, e.g., Ctrl+C) cleanly cancel ongoing Pulumi tasks instead of leaving them running in the background. This completes the fix for **#630**.

### **Changes**

* CLI now creates a cancellable root context.
* Added unified signal handling for **SIGINT/SIGTERM**.
* All manager stack functions now require `ctx`.
* All AWS/Azure provider operations updated to forward that context.
* Replaced all remaining `context.Background()` usages.

### **Why**

Previously, interrupting MAPT didn’t cancel the underlying Pulumi task, often leaving partial resources and inconsistent state. Cancellation is now fully propagated to Pulumi, ensuring immediate, deterministic shutdown.

### **Testing**

* Verified Ctrl+C cancels `aws fedora create` mid-update.
  Command used:

  ```bash
  out/mapt aws fedora create \
    --project-name aipcc-6664-2 \
    --backed-url file:///$PWD/state \
    --conn-details-output $PWD/outputs \
    --compute-sizes g5.xlarge,g5.2xlarge,g4dn.xlarge \
    --cpus 1 \
    --memory 8 \
    --spot-excluded-regions us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1e,us-east-1f,us-east-2a,us-east-2b,us-east-2c
  ```
* Pulumi logs reflect clean cancellation events.
* Destroy operations behave correctly after interruption.

### **Issue**

Fixes **#630**.