### PR TITLE
fix(renovate): registryUrlsTemplate wrong field for gitlab cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ vendor:
 	go mod vendor
 
 .PHONY: check
-check: build test lint
+check: build test lint renovate-check
 
 # Start of the actual build targets
 
@@ -94,6 +94,11 @@ fmt:
 .PHONY: lint 
 lint: $(TOOLS_BINDIR)/golangci-lint
 	"$(TOOLS_BINDIR)"/golangci-lint run -v --timeout 10m
+
+.PHONY: renovate-check
+renovate-check:
+	${CONTAINER_MANAGER} run --rm -v ${PWD}:/repo docker.io/renovate/renovate:latest renovate-config-validator /repo/renovate.json
+	 
 
 # Build the container image
 .PHONY: oci-build

--- a/renovate.json
+++ b/renovate.json
@@ -45,8 +45,7 @@
       ],
       "datasourceTemplate": "gitlab-tags",
       "versioningTemplate": "{{version}}",
-      "packageNameTemplate": "gitlab-org/gitlab-runner",
-      "registryUrlsTemplate": ["https://gitlab.com"]
+      "packageNameTemplate": "gitlab-org/gitlab-runner"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Remove invalid field registryUrlsTemplate for gitlab-tags.

Also added a make target to validate renovate config: make renovate-check.

Fixes #713 