### PR TITLE
feat(eks): enhancements and fixes for EKS

### DIFF
--- a/docs/aws/eks.md
+++ b/docs/aws/eks.md
@@ -4,13 +4,30 @@ This actions will handle provision for EKS cluster instances on AWS.
 
 ## EKS
 
-It creates / destroy a basic EKS Cluster.
+It creates / destroy a basic EKS Cluster. The cluster is provisioned with a managed node group, IAM roles, an OIDC provider for IRSA (IAM Roles for Service Accounts), and optional add-ons like the AWS Load Balancer Controller and EBS CSI driver.
+
+### Prerequisites
+
+* AWS credentials with permissions to create EKS clusters, VPCs, IAM roles, and related resources
+* Credentials exported as environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`
+
+### Architecture
+
+The following AWS resources are created as part of the EKS stack:
+
+* **VPC** with CIDR `10.0.0.0/16` and public subnets across multiple availability zones
+* **VPC Endpoints** for S3, ECR, and SSM (to support private networking)
+* **NAT Gateway** in single mode
+* **EKS Cluster** with public API endpoint access
+* **Managed Node Group** with configurable instance types and scaling
+* **IAM Roles** for the EKS service and node groups, including required AWS managed policies
+* **OIDC Provider** for enabling pod-level IAM roles via service accounts (IRSA)
 
 ### Operations
 
 #### Create
 
-This will create K8s cluster using EKS according to params specified:
+This will create a K8s cluster using EKS according to params specified:
 
 ```bash
 mapt aws eks create -h
@@ -20,21 +37,27 @@ Usage:
   mapt aws eks create [flags]
 
 Flags:
-      --addons strings               List of EKS addons to be installed, separated by commas.
-      --arch string                  architecture for the machine. Allowed x86_64 or arm64 (default "x86_64")
-      --conn-details-output string   path to export host connection information (host, username and privateKey)
-      --cpus int32                   Number of CPUs for the cloud instance (default 8)
-  -h, --help                         help for create
-      --load-balancer-controller     Install AWS Load Balancer Controller
-      --memory int32                 Amount of RAM for the cloud instance in GiB (default 64)
-      --nested-virt                  Use cloud instance that has nested virtualization support
-      --spot                         if spot is set the spot prices across all regions will be checked and machine will be started on best spot option (price / eviction)
-      --spot-increase-rate int       Percentage to be added on top of the current calculated spot price to increase chances to get the machine (default 20)
-      --tags stringToString          tags to add on each resource (--tags name1=value1,name2=value2) (default [])
-      --version string               EKS K8s cluster version (default "1.31")
-      --workers-desired string       Worker nodes scaling desired size (default "1")
-      --workers-max string           Worker nodes scaling maximum size (default "3")
-      --workers-min string           Worker nodes scaling minimum size (default "1")
+      --addons strings                   List of EKS addons to be installed, separated by commas.
+      --arch string                      architecture for the machine. Allowed x86_64 or arm64 (default "x86_64")
+      --compute-sizes strings            Comma seperated list of sizes for the machines to be requested. If set this takes precedence over compute by args
+      --conn-details-output string       path to export host connection information (host, username and privateKey)
+      --cpus int32                       Number of CPUs for the cloud instance (default 8)
+      --excluded-zone-ids strings        Comma-separated list of zone IDs to exclude from availability zone selection
+      --gpu-manufacturer string          Manufacturer company name for GPU. (i.e. NVIDIA)
+      --gpus int32                       Number of GPUs for the cloud instance
+  -h, --help                             help for create
+      --load-balancer-controller         Install AWS Load Balancer Controller
+      --memory int32                     Amount of RAM for the cloud instance in GiB (default 64)
+      --nested-virt                      Use cloud instance that has nested virtualization support
+      --spot                             if spot is set the spot prices across all regions will be checked and machine will be started on best spot option (price / eviction)
+      --spot-eviction-tolerance string   if spot is enable we can define the minimum tolerance level of eviction. Allowed value are: lowest, low, medium, high or highest (default "lowest")
+      --spot-excluded-regions strings    Comma-separated list of zone IDs to exclude from spot selection
+      --spot-increase-rate int           Percentage to be added on top of the current calculated spot price to increase chances to get the machine (default 30)
+      --tags stringToString              tags to add on each resource (--tags name1=value1,name2=value2) (default [])
+      --version string                   EKS K8s cluster version (default "1.31")
+      --workers-desired string           Worker nodes scaling desired size (default "1")
+      --workers-max string               Worker nodes scaling maximum size (default "3")
+      --workers-min string               Worker nodes scaling minimum size (default "1")
 
 Global Flags:
       --backed-url string     backed for stack state. (local) file:///path/subpath (s3) s3://existing-bucket, (azure) azblob://existing-blobcontainer. See more https://www.pulumi.com/docs/iac/concepts/state-and-backends/#using-a-self-managed-backend
@@ -43,21 +66,81 @@ Global Flags:
       --project-name string   project name to identify the instance of the stack
 ```
 
-It will crete an EKS cluster and kubeconfig file to connect will be placed at `--conn-details-output`. To use the kubeconfig file, you need to have the authentication information exported as variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`).
+##### Add-ons
+
+The `--addons` flag accepts any standard EKS add-on name. The `aws-ebs-csi-driver` add-on receives special handling: when installed, mapt automatically creates a dedicated IAM role via OIDC and configures it as the default storage class.
+
+##### AWS Load Balancer Controller
+
+When `--load-balancer-controller` is set, mapt deploys the AWS Load Balancer Controller via Helm. This includes automatic IRSA configuration with the full IAM policy required for ALB/NLB management.
+
+##### Excluded Zone IDs
+
+Some AWS availability zones are incompatible with EKS (see [AWS knowledge center](https://repost.aws/knowledge-center/eks-cluster-creation-errors)). By default, known incompatible zones are excluded. Use `--excluded-zone-ids` to specify additional zones to exclude.
+
+### Outputs
+
+The create operation produces the following output at the path defined by `--conn-details-output`:
+
+* **kubeconfig**: kubeconfig file for connecting to the EKS cluster
+
+The kubeconfig uses AWS CLI exec-based authentication. To use it, you need the AWS CLI installed and the following environment variables exported: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`.
+
+The state for the created resources is stored at the path defined by `--backed-url`. This state is required (with the same `--project-name`) to destroy the resources later.
+
+#### Destroy
+
+```bash
+mapt aws eks destroy -h
+destroy
+
+Usage:
+  mapt aws eks destroy [flags]
+
+Flags:
+      --force-destroy   if force-destroy is set the command will destroy even if there is a lock.
+  -h, --help            help for destroy
+      --keep-state      keep Pulumi state files in S3 backend after successful destroy (by default, state files are removed)
+
+Global Flags:
+      --backed-url string     backed for stack state. (local) file:///path/subpath (s3) s3://existing-bucket, (azure) azblob://existing-blobcontainer. See more https://www.pulumi.com/docs/iac/concepts/state-and-backends/#using-a-self-managed-backend
+      --debug                 Enable debug traces and set verbosity to max. Typically to get information to troubleshooting an issue.
+      --debug-level uint      Set the level of verbosity on debug. You can set from minimum 1 to max 9. (default 3)
+      --project-name string   project name to identify the instance of the stack
+```
+
+### Container
 
 When running the container image it is required to pass the authentication information as variables, following a sample snippet on how to create
-a instance with default values:
+a cluster with default values:
 
 ```bash
 podman run -d --rm \
         -v ${PWD}:/workspace:z \
         -e AWS_ACCESS_KEY_ID=XXX \
         -e AWS_SECRET_ACCESS_KEY=XXX \
-        -e AWS_DEFAULT_REGION=us-east-1 \
+        -e AWS_DEFAULT_REGION=us-east-2 \
         quay.io/redhat-developer/mapt:v1.0.0-dev aws eks create \
             --project-name "mapt-eks" \
             --backed-url file:///workspace \
             --conn-details-output /workspace
+```
+
+Creating an EKS cluster with spot instances, add-ons, and the Load Balancer Controller:
+
+```bash
+podman run -d --rm \
+        -v ${PWD}:/workspace:z \
+        -e AWS_ACCESS_KEY_ID=XXX \
+        -e AWS_SECRET_ACCESS_KEY=XXX \
+        -e AWS_DEFAULT_REGION=us-east-2 \
+        quay.io/redhat-developer/mapt:1.0.0-dev aws eks create \
+            --project-name "mapt-eks" \
+            --backed-url file:///workspace \
+            --conn-details-output /workspace \
+            --spot \
+            --addons aws-ebs-csi-driver \
+            --load-balancer-controller
 ```
 
 It is important to notice that backed-url contains the state of the resources on AWS linked to the EKS creation, to destroy we need to reference them as so we should pass same folder as we set for creation:
@@ -67,7 +150,7 @@ podman run -d --rm \
         -v ${PWD}:/workspace:z \
         -e AWS_ACCESS_KEY_ID=XXX \
         -e AWS_SECRET_ACCESS_KEY=XXX \
-        -e AWS_DEFAULT_REGION=us-east-1 \
+        -e AWS_DEFAULT_REGION=us-east-2 \
     quay.io/redhat-developer/mapt:v1.0.0-dev aws eks destroy \
             --project-name "mapt-eks" \
             --backed-url file:///workspace

--- a/pkg/provider/aws/action/eks/eks.go
+++ b/pkg/provider/aws/action/eks/eks.go
@@ -16,6 +16,7 @@ import (
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 	"github.com/redhat-developer/mapt/pkg/integrations/cirrus"
 	"github.com/redhat-developer/mapt/pkg/manager"
 	mc "github.com/redhat-developer/mapt/pkg/manager/context"
@@ -53,6 +54,7 @@ type eksRequest struct {
 	mCtx                   *mc.Context `validate:"required"`
 	prefix                 *string
 	kubernetesVersion      *string
+	arch                   *string
 	scalingDesiredSize     *int
 	scalingMaxSize         *int
 	scalingMinSize         *int
@@ -82,10 +84,12 @@ func Create(mCtxArgs *mc.ContextArgs, args *EKSArgs) (err error) {
 		return err
 	}
 	prefix := util.If(len(args.Prefix) > 0, args.Prefix, "main")
+	arch := archFromComputeRequest(args.ComputeRequest.Arch)
 	r := eksRequest{
 		mCtx:                   mCtx,
 		prefix:                 &prefix,
 		kubernetesVersion:      &args.KubernetesVersion,
+		arch:                   &arch,
 		scalingDesiredSize:     &args.ScalingDesiredSize,
 		scalingMaxSize:         &args.ScalingMaxSize,
 		scalingMinSize:         &args.ScalingMinSize,
@@ -191,6 +195,10 @@ func (r *eksRequest) deployer(ctx *pulumi.Context) error {
 	// Create EKS Cluster
 	eksCluster, err := eks.NewCluster(ctx, "eks-cluster", &eks.ClusterArgs{
 		RoleArn: eksRole.Arn,
+		AccessConfig: &eks.ClusterAccessConfigArgs{
+			AuthenticationMode:                      pulumi.String("API_AND_CONFIG_MAP"),
+			BootstrapClusterCreatorAdminPermissions: pulumi.Bool(true),
+		},
 		VpcConfig: &eks.ClusterVpcConfigArgs{
 			PublicAccessCidrs: pulumi.StringArray{
 				pulumi.String("0.0.0.0/0"),
@@ -199,15 +207,24 @@ func (r *eksRequest) deployer(ctx *pulumi.Context) error {
 			SubnetIds:        subnetIds,
 		},
 		Version: pulumi.String(*r.kubernetesVersion),
+		Tags:    r.mCtx.ResourceTags(),
 	}, pulumi.DependsOn([]pulumi.Resource{eksRole}))
 	if err != nil {
 		return err
 	}
 
 	kubeconfig := generateKubeconfig(eksCluster.Endpoint, eksCluster.CertificateAuthority.Data().Elem(), eksCluster.Name)
-	// Create a Kubernetes provider instance
+
+	// Get cluster auth token using the AWS SDK (avoids dependency on the aws CLI binary)
+	clusterAuth := eks.GetClusterAuthOutput(ctx, eks.GetClusterAuthOutputArgs{
+		Name: eksCluster.Name,
+	})
+	// Generate a token-based kubeconfig for the Pulumi k8s provider
+	providerKubeconfig := generateTokenKubeconfig(eksCluster.Endpoint, eksCluster.CertificateAuthority.Data().Elem(), clusterAuth.Token())
+
+	// Create a Kubernetes provider instance using token-based auth
 	k8sProvider, err := kubernetes.NewProvider(ctx, "k8sProvider", &kubernetes.ProviderArgs{
-		Kubeconfig: kubeconfig,
+		Kubeconfig: providerKubeconfig,
 	}, pulumi.DependsOn([]pulumi.Resource{eksCluster}))
 	if err != nil {
 		return err
@@ -224,7 +241,8 @@ func (r *eksRequest) deployer(ctx *pulumi.Context) error {
 		ClientIdLists: pulumi.StringArray{
 			pulumi.String("sts.amazonaws.com"),
 		},
-		Url: oidcIssuerUrl,
+		Url:  oidcIssuerUrl,
+		Tags: r.mCtx.ResourceTags(),
 	}, pulumi.DependsOn([]pulumi.Resource{eksCluster}))
 	if err != nil {
 		return err
@@ -241,38 +259,51 @@ func (r *eksRequest) deployer(ctx *pulumi.Context) error {
 		return parsedUrl.Host + parsedUrl.Path, nil
 	}).(pulumi.StringOutput)
 
-	err = deployAddons(r, oidcIssuerHostPath, accountId, ctx, eksCluster)
-	if err != nil {
-		return err
-	}
-
-	nodeGroup0, err := eks.NewNodeGroup(ctx, "node-group-0", &eks.NodeGroupArgs{
-		ClusterName:   eksCluster.Name,
-		NodeGroupName: pulumi.String("eks-nodegroup-0"),
-		NodeRoleArn:   nodeGroupRole.Arn,
-		SubnetIds:     subnetIds,
-		InstanceTypes: pulumi.StringArray(util.ArrayConvert(
-			r.allocationData.InstanceTypes,
-			func(s string) pulumi.StringInput {
-				return pulumi.String(s)
-			})),
-		ScalingConfig: &eks.NodeGroupScalingConfigArgs{
-			DesiredSize: pulumi.Int(*r.scalingDesiredSize),
-			MaxSize:     pulumi.Int(*r.scalingMaxSize),
-			MinSize:     pulumi.Int(*r.scalingMinSize),
-		},
-		CapacityType: util.If(r.allocationData != nil && r.allocationData.SpotPrice != nil,
-			pulumi.String("SPOT"),
-			pulumi.String("ON_DEMAND")),
+	// Create access entry for self-managed nodes
+	accessEntry, err := eks.NewAccessEntry(ctx, "node-access", &eks.AccessEntryArgs{
+		ClusterName:  eksCluster.Name,
+		PrincipalArn: nodeGroupRole.Arn,
+		Type:         pulumi.String("EC2_LINUX"),
+		Tags:         r.mCtx.ResourceTags(),
 	}, pulumi.DependsOn([]pulumi.Resource{eksCluster, nodeGroupRole}))
 	if err != nil {
 		return err
 	}
 
-	// Install AWS Load Balancer Controller
+	// Create self-managed node group
+	nodeGroup0, err := createSelfManagedNodeGroup(ctx, &selfManagedNodeGroupArgs{
+		prefix:            *r.prefix,
+		kubernetesVersion: *r.kubernetesVersion,
+		arch:              *r.arch,
+		eksCluster:        eksCluster,
+		nodeGroupRole:     nodeGroupRole,
+		securityGroups:    securityGroups,
+		subnetIds:         subnetIds,
+		instanceTypes:     r.allocationData.InstanceTypes,
+		scalingDesired:    *r.scalingDesiredSize,
+		scalingMax:        *r.scalingMaxSize,
+		scalingMin:        *r.scalingMinSize,
+		spotPrice:         r.allocationData.SpotPrice,
+		accessEntry:       accessEntry,
+		tags:              r.mCtx.ResourceTags(),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Deploy addons after node group so nodes are available for addon pods to schedule
+	corednsAddon, err := deployAddons(r, oidcIssuerHostPath, accountId, ctx, eksCluster, nodeGroup0)
+	if err != nil {
+		return err
+	}
+
+	// Install AWS Load Balancer Controller (depends on coredns for DNS resolution)
 	if *r.loadBalancerController {
-		// IAM Policy Document
-		err := r.installAwsLoadBalancerController(ctx, oidcIssuerHostPath, accountId, k8sProvider, eksCluster, vpc, nodeGroup0)
+		var lbcDeps []pulumi.Resource
+		if corednsAddon != nil {
+			lbcDeps = append(lbcDeps, corednsAddon)
+		}
+		err := r.installAwsLoadBalancerController(ctx, oidcIssuerHostPath, accountId, k8sProvider, eksCluster, vpc, nodeGroup0, lbcDeps)
 		if err != nil {
 			return err
 		}
@@ -337,7 +368,7 @@ func (r *eksRequest) securityGroups(ctx *pulumi.Context,
 	return pulumi.StringArray(sgs[:]), nil
 }
 
-func (*eksRequest) createEksRole(ctx *pulumi.Context) (*iam.Role, error) {
+func (r *eksRequest) createEksRole(ctx *pulumi.Context) (*iam.Role, error) {
 	eksRolePolicyJSON, err := json.Marshal(map[string]interface{}{
 		"Version": "2012-10-17",
 		"Statement": []map[string]interface{}{
@@ -355,6 +386,7 @@ func (*eksRequest) createEksRole(ctx *pulumi.Context) (*iam.Role, error) {
 	}
 	eksRole, err := iam.NewRole(ctx, "eks-iam-eksRole", &iam.RoleArgs{
 		AssumeRolePolicy: pulumi.String(eksRolePolicyJSON),
+		Tags:             r.mCtx.ResourceTags(),
 	})
 	if err != nil {
 		return nil, err
@@ -375,7 +407,7 @@ func (*eksRequest) createEksRole(ctx *pulumi.Context) (*iam.Role, error) {
 	return eksRole, nil
 }
 
-func (*eksRequest) createNodeGroupRole(ctx *pulumi.Context) (*iam.Role, error) {
+func (r *eksRequest) createNodeGroupRole(ctx *pulumi.Context) (*iam.Role, error) {
 	nodeGroupAssumeRolePolicyJSON, err := json.Marshal(map[string]interface{}{
 		"Version": "2012-10-17",
 		"Statement": []map[string]interface{}{
@@ -393,6 +425,7 @@ func (*eksRequest) createNodeGroupRole(ctx *pulumi.Context) (*iam.Role, error) {
 	}
 	nodeGroupRole, err := iam.NewRole(ctx, "nodegroup-iam-role", &iam.RoleArgs{
 		AssumeRolePolicy: pulumi.String(nodeGroupAssumeRolePolicyJSON),
+		Tags:             r.mCtx.ResourceTags(),
 	})
 	if err != nil {
 		return nil, err
@@ -414,12 +447,13 @@ func (*eksRequest) createNodeGroupRole(ctx *pulumi.Context) (*iam.Role, error) {
 	return nodeGroupRole, nil
 }
 
-func (r *eksRequest) installAwsLoadBalancerController(ctx *pulumi.Context, oidcIssuerHostPath pulumi.StringOutput, accountId string, k8sProvider *kubernetes.Provider, eksCluster *eks.Cluster, vpc *ec2.Vpc, nodeGroup0 *eks.NodeGroup) error {
+func (r *eksRequest) installAwsLoadBalancerController(ctx *pulumi.Context, oidcIssuerHostPath pulumi.StringOutput, accountId string, k8sProvider *kubernetes.Provider, eksCluster *eks.Cluster, vpc *ec2.Vpc, nodeGroup0 pulumi.Resource, extraDeps []pulumi.Resource) error {
 	policyDocumentJSON := getAwsLoadBalancerControllerIamPolicy()
 
 	// Create IAM policy
 	albControllerPolicyAttachment, err := iam.NewPolicy(ctx, "loadBalancerControllerPolicy", &iam.PolicyArgs{
 		Policy: pulumi.String(policyDocumentJSON),
+		Tags:   r.mCtx.ResourceTags(),
 	})
 	if err != nil {
 		return err
@@ -456,6 +490,7 @@ func (r *eksRequest) installAwsLoadBalancerController(ctx *pulumi.Context, oidcI
 	iamRole, err := iam.NewRole(ctx, "loadBalancerControllerRole", &iam.RoleArgs{
 		NamePrefix:       pulumi.String("MaptLBCRole-"),
 		AssumeRolePolicy: assumeRolePolicyJSON,
+		Tags:             r.mCtx.ResourceTags(),
 	})
 	if err != nil {
 		return err
@@ -500,143 +535,235 @@ func (r *eksRequest) installAwsLoadBalancerController(ctx *pulumi.Context, oidcI
 			"region": pulumi.String(*r.allocationData.Region),
 			"vpcId":  vpc.ID(),
 		},
-	}, pulumi.Provider(k8sProvider), pulumi.DependsOn([]pulumi.Resource{eksCluster, nodeGroup0, iamRole, lbcK8sServiceAccount}))
+	}, pulumi.Provider(k8sProvider), pulumi.DependsOn(append([]pulumi.Resource{eksCluster, nodeGroup0, iamRole, lbcK8sServiceAccount}, extraDeps...)))
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func deployAddons(r *eksRequest, oidcIssuerHostPath pulumi.StringOutput, accountId string, ctx *pulumi.Context, eksCluster *eks.Cluster) error {
+// deployAddons deploys EKS addons in the correct dependency order:
+//   - Phase 1 (infrastructure): vpc-cni, kube-proxy, eks-pod-identity-agent
+//     These are DaemonSet-based addons that provide basic node networking and need only nodes.
+//   - Phase 2 (core services): coredns
+//     Requires vpc-cni to be running so pods can get IP addresses assigned.
+//   - Phase 3 (storage/other): aws-ebs-csi-driver and any remaining addons
+//     Requires coredns for DNS resolution of AWS API endpoints.
+//
+// It returns the coredns addon resource (if deployed) so the LB controller can depend on it.
+func deployAddons(r *eksRequest, oidcIssuerHostPath pulumi.StringOutput, accountId string, ctx *pulumi.Context, eksCluster *eks.Cluster, nodeGroup pulumi.Resource) (*eks.Addon, error) {
+	// Classify addons into deployment phases
+	infraAddons := []string{}     // Phase 1: DaemonSet-based networking/identity addons
+	var hasCoredns bool           // Phase 2: coredns
+	remainingAddons := []string{} // Phase 3: everything else (aws-ebs-csi-driver, etc.)
+
 	for _, addon := range r.addons {
+		switch addon {
+		case "vpc-cni", "kube-proxy", "eks-pod-identity-agent":
+			infraAddons = append(infraAddons, addon)
+		case "coredns":
+			hasCoredns = true
+		default:
+			remainingAddons = append(remainingAddons, addon)
+		}
+	}
+
+	// Phase 1: Deploy infrastructure addons (depend only on nodeGroup)
+	infraAddonResources := []pulumi.Resource{}
+	for _, addon := range infraAddons {
+		a, err := eks.NewAddon(ctx, addon, &eks.AddonArgs{
+			ClusterName:              eksCluster.Name,
+			AddonName:                pulumi.String(addon),
+			ResolveConflictsOnCreate: pulumi.String("OVERWRITE"),
+			Tags:                     r.mCtx.ResourceTags(),
+		}, pulumi.DeletedWith(eksCluster),
+			pulumi.DependsOn([]pulumi.Resource{nodeGroup}),
+			pulumi.Timeouts(&pulumi.CustomTimeouts{Create: "30m"}))
+		if err != nil {
+			return nil, err
+		}
+		infraAddonResources = append(infraAddonResources, a)
+	}
+
+	// Phase 2: Deploy coredns (depends on infrastructure addons being ready)
+	var corednsAddon *eks.Addon
+	if hasCoredns {
+		corednsDeps := append([]pulumi.Resource{nodeGroup}, infraAddonResources...)
+		var err error
+		corednsAddon, err = eks.NewAddon(ctx, "coredns", &eks.AddonArgs{
+			ClusterName:              eksCluster.Name,
+			AddonName:                pulumi.String("coredns"),
+			ResolveConflictsOnCreate: pulumi.String("OVERWRITE"),
+			Tags:                     r.mCtx.ResourceTags(),
+		}, pulumi.DeletedWith(eksCluster),
+			pulumi.DependsOn(corednsDeps),
+			pulumi.Timeouts(&pulumi.CustomTimeouts{Create: "30m"}))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Phase 3: Deploy remaining addons (depend on coredns for DNS resolution)
+	phase3Deps := append([]pulumi.Resource{nodeGroup}, infraAddonResources...)
+	if corednsAddon != nil {
+		phase3Deps = append(phase3Deps, corednsAddon)
+	}
+	for _, addon := range remainingAddons {
 		if addon == "aws-ebs-csi-driver" {
-			// Create the IAM role for the EBS CSI driver
-			ebsCsiDriverServiceAccountName := pulumi.String("ebs-csi-controller-sa")
-
-			assumeRolePolicyJSON := oidcIssuerHostPath.ApplyT(func(hostPath string) (string, error) {
-				policy, err := json.Marshal(map[string]interface{}{
-					"Version": "2012-10-17",
-					"Statement": []map[string]interface{}{
-						{
-							"Effect": "Allow",
-							"Principal": map[string]interface{}{
-								"Federated": fmt.Sprintf("arn:aws:iam::%s:oidc-provider/%s", accountId, hostPath),
-							},
-							"Action": "sts:AssumeRoleWithWebIdentity",
-							"Condition": map[string]interface{}{
-								"StringEquals": map[string]interface{}{
-									fmt.Sprintf("%s:aud", hostPath): "sts.amazonaws.com",
-									fmt.Sprintf("%s:sub", hostPath): fmt.Sprintf("system:serviceaccount:kube-system:%s", ebsCsiDriverServiceAccountName),
-								},
-							},
-						},
-					},
-				})
-				if err != nil {
-					return "", err
-				}
-				return string(policy), nil
-			}).(pulumi.StringOutput)
-
-			awsEbsCsiDriverRole, err := iam.NewRole(ctx, "AmazonEKS_EBS_CSI_DriverRole", &iam.RoleArgs{
-				NamePrefix:       pulumi.String("MaptEBSCSIDriverRole-"),
-				AssumeRolePolicy: assumeRolePolicyJSON,
-			})
-			if err != nil {
-				return err
+			if err := deployEbsCsiDriver(ctx, r.mCtx, addon, oidcIssuerHostPath, accountId, eksCluster, phase3Deps); err != nil {
+				return nil, err
 			}
-			_, err = iam.NewRolePolicyAttachment(ctx, "AmazonEBSCSIDriverPolicyAttachment", &iam.RolePolicyAttachmentArgs{
-				PolicyArn: pulumi.String("arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"),
-				Role:      awsEbsCsiDriverRole.Name,
-			})
-			if err != nil {
-				return err
-			}
-
-			// Enable addon and set as default storage class
-			configValues, err := json.Marshal(map[string]interface{}{
-				"defaultStorageClass": map[string]interface{}{
-					"enabled": true,
-				},
-			})
-			if err != nil {
-				return err
-			}
-			_, err = eks.NewAddon(ctx, addon, &eks.AddonArgs{
-				ClusterName:           eksCluster.Name,
-				AddonName:             pulumi.String(addon),
-				ServiceAccountRoleArn: awsEbsCsiDriverRole.Arn,
-				ConfigurationValues:   pulumi.String(configValues),
-			}, pulumi.DeletedWith(eksCluster))
-			if err != nil {
-				return err
-			}
-
 		} else {
 			_, err := eks.NewAddon(ctx, addon, &eks.AddonArgs{
-				ClusterName: eksCluster.Name,
-				AddonName:   pulumi.String(addon),
-			}, pulumi.DeletedWith(eksCluster))
+				ClusterName:              eksCluster.Name,
+				AddonName:                pulumi.String(addon),
+				ResolveConflictsOnCreate: pulumi.String("OVERWRITE"),
+				Tags:                     r.mCtx.ResourceTags(),
+			}, pulumi.DeletedWith(eksCluster),
+				pulumi.DependsOn(phase3Deps),
+				pulumi.Timeouts(&pulumi.CustomTimeouts{Create: "30m"}))
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
-	return nil
+	return corednsAddon, nil
 }
 
-// Create the KubeConfig Structure as per https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
-func generateKubeconfig(clusterEndpoint pulumi.StringOutput, certData pulumi.StringOutput, clusterName pulumi.StringOutput) pulumi.StringOutput {
-	return pulumi.All(clusterEndpoint, certData, clusterName).ApplyT(func(args []interface{}) (string, error) {
-		endpoint := args[0].(string)
-		cert := args[1].(string)
-		name := args[2].(string)
-		kubeconfigMap := map[string]interface{}{
-			"apiVersion": "v1",
-			"clusters": []map[string]interface{}{
+// deployEbsCsiDriver handles the special-case deployment of the aws-ebs-csi-driver addon
+// which requires an IRSA role for accessing EBS APIs.
+func deployEbsCsiDriver(ctx *pulumi.Context, mCtx *mc.Context, addon string, oidcIssuerHostPath pulumi.StringOutput, accountId string, eksCluster *eks.Cluster, deps []pulumi.Resource) error {
+	ebsCsiDriverServiceAccountName := pulumi.String("ebs-csi-controller-sa")
+
+	assumeRolePolicyJSON := oidcIssuerHostPath.ApplyT(func(hostPath string) (string, error) {
+		policy, err := json.Marshal(map[string]interface{}{
+			"Version": "2012-10-17",
+			"Statement": []map[string]interface{}{
 				{
-					"name": "kubernetes",
-					"cluster": map[string]interface{}{
-						"server":                     endpoint,
-						"certificate-authority-data": cert,
+					"Effect": "Allow",
+					"Principal": map[string]interface{}{
+						"Federated": fmt.Sprintf("arn:aws:iam::%s:oidc-provider/%s", accountId, hostPath),
 					},
-				},
-			},
-			"contexts": []map[string]interface{}{
-				{
-					"name": "aws",
-					"context": map[string]interface{}{
-						"cluster": "kubernetes",
-						"user":    "aws",
-					},
-				},
-			},
-			"current-context": "aws",
-			"kind":            "Config",
-			"users": []map[string]interface{}{
-				{
-					"name": "aws",
-					"user": map[string]interface{}{
-						"exec": map[string]interface{}{
-							"apiVersion": "client.authentication.k8s.io/v1beta1",
-							"command":    "aws",
-							"args": []string{
-								"eks",
-								"get-token",
-								"--cluster-name",
-								name,
-							},
+					"Action": "sts:AssumeRoleWithWebIdentity",
+					"Condition": map[string]interface{}{
+						"StringEquals": map[string]interface{}{
+							fmt.Sprintf("%s:aud", hostPath): "sts.amazonaws.com",
+							fmt.Sprintf("%s:sub", hostPath): fmt.Sprintf("system:serviceaccount:kube-system:%s", ebsCsiDriverServiceAccountName),
 						},
 					},
 				},
 			},
-		}
-		kubeconfigJson, err := json.MarshalIndent(kubeconfigMap, "", "  ")
+		})
 		if err != nil {
-			return "", fmt.Errorf("error generating kubeconfig: %w", err)
+			return "", err
 		}
-		return string(kubeconfigJson), nil
+		return string(policy), nil
 	}).(pulumi.StringOutput)
+
+	awsEbsCsiDriverRole, err := iam.NewRole(ctx, "AmazonEKS_EBS_CSI_DriverRole", &iam.RoleArgs{
+		NamePrefix:       pulumi.String("MaptEBSCSIDriverRole-"),
+		AssumeRolePolicy: assumeRolePolicyJSON,
+		Tags:             mCtx.ResourceTags(),
+	})
+	if err != nil {
+		return err
+	}
+	_, err = iam.NewRolePolicyAttachment(ctx, "AmazonEBSCSIDriverPolicyAttachment", &iam.RolePolicyAttachmentArgs{
+		PolicyArn: pulumi.String("arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"),
+		Role:      awsEbsCsiDriverRole.Name,
+	})
+	if err != nil {
+		return err
+	}
+
+	configValues, err := json.Marshal(map[string]interface{}{
+		"defaultStorageClass": map[string]interface{}{
+			"enabled": true,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	_, err = eks.NewAddon(ctx, addon, &eks.AddonArgs{
+		ClusterName:              eksCluster.Name,
+		AddonName:                pulumi.String(addon),
+		ServiceAccountRoleArn:    awsEbsCsiDriverRole.Arn,
+		ConfigurationValues:      pulumi.String(configValues),
+		ResolveConflictsOnCreate: pulumi.String("OVERWRITE"),
+		Tags:                     mCtx.ResourceTags(),
+	}, pulumi.DeletedWith(eksCluster),
+		pulumi.DependsOn(deps),
+		pulumi.Timeouts(&pulumi.CustomTimeouts{Create: "30m"}))
+	return err
+}
+
+// buildKubeconfig creates a kubeconfig JSON string with the given endpoint, cert, and user auth config.
+func buildKubeconfig(endpoint, cert string, userAuth map[string]interface{}) (string, error) {
+	kubeconfigMap := map[string]interface{}{
+		"apiVersion": "v1",
+		"clusters": []map[string]interface{}{
+			{
+				"name": "kubernetes",
+				"cluster": map[string]interface{}{
+					"server":                     endpoint,
+					"certificate-authority-data": cert,
+				},
+			},
+		},
+		"contexts": []map[string]interface{}{
+			{
+				"name": "aws",
+				"context": map[string]interface{}{
+					"cluster": "kubernetes",
+					"user":    "aws",
+				},
+			},
+		},
+		"current-context": "aws",
+		"kind":            "Config",
+		"users": []map[string]interface{}{
+			{
+				"name": "aws",
+				"user": userAuth,
+			},
+		},
+	}
+	kubeconfigJson, err := json.MarshalIndent(kubeconfigMap, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("error generating kubeconfig: %w", err)
+	}
+	return string(kubeconfigJson), nil
+}
+
+// generateTokenKubeconfig creates a kubeconfig with an embedded token for use by the Pulumi k8s provider.
+func generateTokenKubeconfig(clusterEndpoint, certData, token pulumi.StringOutput) pulumi.StringOutput {
+	return pulumix.Cast[pulumi.StringOutput](
+		pulumix.Apply3Err(clusterEndpoint, certData, token,
+			func(endpoint, cert, t string) (string, error) {
+				return buildKubeconfig(endpoint, cert, map[string]interface{}{
+					"token": t,
+				})
+			}))
+}
+
+// Create the KubeConfig Structure as per https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
+func generateKubeconfig(clusterEndpoint, certData, clusterName pulumi.StringOutput) pulumi.StringOutput {
+	return pulumix.Cast[pulumi.StringOutput](
+		pulumix.Apply3Err(clusterEndpoint, certData, clusterName,
+			func(endpoint, cert, name string) (string, error) {
+				return buildKubeconfig(endpoint, cert, map[string]interface{}{
+					"exec": map[string]interface{}{
+						"apiVersion": "client.authentication.k8s.io/v1beta1",
+						"command":    "aws",
+						"args": []string{
+							"eks",
+							"get-token",
+							"--cluster-name",
+							name,
+						},
+					},
+				})
+			}))
 }
 
 // Write exported values in context to files o a selected target folder
@@ -901,4 +1028,13 @@ func getAwsLoadBalancerControllerIamPolicy() json.RawMessage {
 			]
 	}`)
 	return policyDocumentJSON
+}
+
+// archFromComputeRequest converts the compute-request Arch enum to
+// the AWS architecture string used in AMI names and filters.
+func archFromComputeRequest(a cr.Arch) string {
+	if a == cr.Arm64 {
+		return "arm64"
+	}
+	return "x86_64"
 }

--- a/pkg/provider/aws/action/eks/eks.go
+++ b/pkg/provider/aws/action/eks/eks.go
@@ -159,7 +159,7 @@ func (r *eksRequest) deployer(ctx *pulumi.Context) error {
 		AvailabilityZones:  r.availabilityZones,
 		PublicSubnetsCIDRs: network.GeneratePublicSubnetCIDRs(len(r.availabilityZones)),
 		Region:             *r.allocationData.Region,
-		NatGatewayMode:     &network.NatGatewayModeSingle,
+		NatGatewayMode:     &network.NatGatewayModeNone,
 		MapPublicIp:        true,
 		ServiceEndpoints:   r.serviceEndpoints,
 	}.CreateNetwork(ctx)

--- a/pkg/provider/aws/action/eks/nodegroup.go
+++ b/pkg/provider/aws/action/eks/nodegroup.go
@@ -1,0 +1,249 @@
+package eks
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/autoscaling"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/ec2"
+	eksaws "github.com/pulumi/pulumi-aws/sdk/v7/go/aws/eks"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/iam"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/redhat-developer/mapt/pkg/provider/aws/constants"
+	ami "github.com/redhat-developer/mapt/pkg/provider/aws/services/ec2/ami"
+	resourcesUtil "github.com/redhat-developer/mapt/pkg/util/resources"
+)
+
+const (
+	eksNodeDiskSize = 200
+)
+
+type selfManagedNodeGroupArgs struct {
+	prefix            string
+	kubernetesVersion string
+	arch              string
+	eksCluster        *eksaws.Cluster
+	nodeGroupRole     *iam.Role
+	securityGroups    pulumi.StringArray
+	subnetIds         pulumi.StringArray
+	instanceTypes     []string
+	scalingDesired    int
+	scalingMax        int
+	scalingMin        int
+	spotPrice         *float64
+	accessEntry       *eksaws.AccessEntry
+	tags              pulumi.StringMap
+}
+
+// createSelfManagedNodeGroup creates an ASG-based self-managed EKS node group.
+// For spot mode (spotPrice != nil), it sets SpotMaxPrice on the ASG mixed instances policy.
+// For on-demand mode, it uses 100% on-demand capacity.
+func createSelfManagedNodeGroup(ctx *pulumi.Context, args *selfManagedNodeGroupArgs) (*autoscaling.Group, error) {
+	// Look up EKS-optimized AL2023 AMI
+	eksAMI, err := ami.GetAMIByName(ctx,
+		fmt.Sprintf("amazon-eks-node-al2023-%s-standard-%s-*", args.arch, args.kubernetesVersion),
+		[]string{"amazon"},
+		map[string]string{"architecture": args.arch})
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up EKS-optimized AMI: %w", err)
+	}
+
+	// Create IAM instance profile from the node role
+	instanceProfile, err := iam.NewInstanceProfile(ctx, "eks-node-instance-profile", &iam.InstanceProfileArgs{
+		Role: args.nodeGroupRole.Name,
+		Tags: args.tags,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Build nodeadm userdata using cluster outputs
+	userData := generateNodeadmUserData(
+		args.eksCluster.Name,
+		args.eksCluster.Endpoint,
+		args.eksCluster.CertificateAuthority.Data().Elem(),
+		args.eksCluster.KubernetesNetworkConfig.ServiceIpv4Cidr().Elem(),
+	)
+
+	// Merge custom SGs with the cluster's managed SG
+	// ClusterSecurityGroupId() returns StringPtrOutput; .Elem() converts to StringOutput (implements StringInput)
+	allSecurityGroups := append(
+		args.securityGroups,
+		args.eksCluster.VpcConfig.ClusterSecurityGroupId().Elem(),
+	)
+
+	// Build cluster name tag for EKS discovery
+	clusterTag := args.eksCluster.Name.ApplyT(func(name string) map[string]string {
+		return map[string]string{
+			fmt.Sprintf("kubernetes.io/cluster/%s", name): "owned",
+		}
+	}).(pulumi.StringMapOutput)
+
+	// Merge resource tags with the EKS cluster tag
+	instanceTags := pulumi.All(args.tags, clusterTag).ApplyT(
+		func(all []interface{}) map[string]string {
+			merged := make(map[string]string)
+			if baseTags, ok := all[0].(map[string]string); ok {
+				for k, v := range baseTags {
+					merged[k] = v
+				}
+			}
+			if eksTags, ok := all[1].(map[string]string); ok {
+				for k, v := range eksTags {
+					merged[k] = v
+				}
+			}
+			return merged
+		},
+	).(pulumi.StringMapOutput)
+
+	// Create launch template
+	lt, err := ec2.NewLaunchTemplate(ctx,
+		resourcesUtil.GetResourceName(args.prefix, awsEKSID, "lt"),
+		&ec2.LaunchTemplateArgs{
+			NamePrefix: pulumi.String(awsEKSID),
+			ImageId:    pulumi.String(eksAMI.Id),
+			IamInstanceProfile: ec2.LaunchTemplateIamInstanceProfileArgs{
+				Arn: instanceProfile.Arn,
+			},
+			UserData: userData,
+			NetworkInterfaces: ec2.LaunchTemplateNetworkInterfaceArray{
+				&ec2.LaunchTemplateNetworkInterfaceArgs{
+					SecurityGroups:           allSecurityGroups,
+					AssociatePublicIpAddress: pulumi.String("true"),
+				},
+			},
+			BlockDeviceMappings: ec2.LaunchTemplateBlockDeviceMappingArray{
+				&ec2.LaunchTemplateBlockDeviceMappingArgs{
+					DeviceName: pulumi.String("/dev/xvda"),
+					Ebs: &ec2.LaunchTemplateBlockDeviceMappingEbsArgs{
+						VolumeSize: pulumi.Int(eksNodeDiskSize),
+					},
+				},
+			},
+			Tags: instanceTags,
+			TagSpecifications: ec2.LaunchTemplateTagSpecificationArray{
+				&ec2.LaunchTemplateTagSpecificationArgs{
+					ResourceType: pulumi.String(constants.PulumiAwsResourceInstance),
+					Tags:         instanceTags,
+				},
+				&ec2.LaunchTemplateTagSpecificationArgs{
+					ResourceType: pulumi.String(constants.PulumiAwsResourceVolume),
+					Tags:         instanceTags,
+				},
+				&ec2.LaunchTemplateTagSpecificationArgs{
+					ResourceType: pulumi.String(constants.PulumiAwsResourceNetworkInterface),
+					Tags:         instanceTags,
+				},
+			},
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	// Build instance type overrides
+	overrides := autoscaling.GroupMixedInstancesPolicyLaunchTemplateOverrideArray{}
+	for _, instanceType := range args.instanceTypes {
+		overrides = append(overrides, &autoscaling.GroupMixedInstancesPolicyLaunchTemplateOverrideArgs{
+			InstanceType: pulumi.String(instanceType),
+		})
+	}
+
+	// Build instances distribution (spot vs on-demand)
+	distribution := &autoscaling.GroupMixedInstancesPolicyInstancesDistributionArgs{}
+	if args.spotPrice != nil {
+		spotMaxPrice := strconv.FormatFloat(*args.spotPrice, 'f', -1, 64)
+		distribution.OnDemandBaseCapacity = pulumi.Int(0)
+		distribution.OnDemandPercentageAboveBaseCapacity = pulumi.Int(0)
+		distribution.SpotAllocationStrategy = pulumi.String("capacity-optimized")
+		distribution.SpotMaxPrice = pulumi.String(spotMaxPrice)
+	} else {
+		distribution.OnDemandPercentageAboveBaseCapacity = pulumi.Int(100)
+	}
+
+	mixedInstancesPolicy := &autoscaling.GroupMixedInstancesPolicyArgs{
+		InstancesDistribution: distribution,
+		LaunchTemplate: &autoscaling.GroupMixedInstancesPolicyLaunchTemplateArgs{
+			LaunchTemplateSpecification: &autoscaling.GroupMixedInstancesPolicyLaunchTemplateLaunchTemplateSpecificationArgs{
+				LaunchTemplateId: lt.ID(),
+			},
+			Overrides: overrides,
+		},
+	}
+
+	// Build ASG tags: Name + resource tags
+	asgName := resourcesUtil.GetResourceName(args.prefix, awsEKSID, "asg")
+	asgTags := autoscaling.GroupTagArray{
+		&autoscaling.GroupTagArgs{
+			Key:               pulumi.String("Name"),
+			Value:             pulumi.String(asgName),
+			PropagateAtLaunch: pulumi.Bool(true),
+		},
+	}
+	for k, v := range args.tags {
+		asgTags = append(asgTags, &autoscaling.GroupTagArgs{
+			Key:               pulumi.String(k),
+			Value:             v,
+			PropagateAtLaunch: pulumi.Bool(true),
+		})
+	}
+
+	// Dependencies: access entry must exist before nodes try to join
+	dependsOn := []pulumi.Resource{args.eksCluster, args.nodeGroupRole, instanceProfile}
+	if args.accessEntry != nil {
+		dependsOn = append(dependsOn, args.accessEntry)
+	}
+
+	return autoscaling.NewGroup(ctx, asgName,
+		&autoscaling.GroupArgs{
+			DesiredCapacity:        pulumi.Int(args.scalingDesired),
+			MaxSize:                pulumi.Int(args.scalingMax),
+			MinSize:                pulumi.Int(args.scalingMin),
+			VpcZoneIdentifiers:     args.subnetIds,
+			MixedInstancesPolicy:   mixedInstancesPolicy,
+			Tags:                   asgTags,
+			WaitForCapacityTimeout: pulumi.String("15m"),
+			HealthCheckType:        pulumi.String("EC2"),
+			HealthCheckGracePeriod: pulumi.Int(300),
+		},
+		pulumi.DependsOn(dependsOn))
+}
+
+// generateNodeadmUserData builds base64-encoded MIME userdata for nodeadm bootstrap.
+// Cluster name, endpoint, CA, and service CIDR are pulumi.StringOutput values resolved at deploy time.
+// The service CIDR (cidr field) is required for AL2023 nodeadm to properly configure
+// pod networking without needing to call the DescribeCluster API.
+func generateNodeadmUserData(
+	clusterName, endpoint, certificateAuthority, serviceCIDR pulumi.StringOutput,
+) pulumi.StringPtrInput {
+	return pulumi.All(clusterName, endpoint, certificateAuthority, serviceCIDR).ApplyT(
+		func(args []interface{}) *string {
+			name := args[0].(string)
+			ep := args[1].(string)
+			ca := args[2].(string)
+			cidr := args[3].(string)
+
+			nodeConfig := fmt.Sprintf(`MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="BOUNDARY"
+
+--BOUNDARY
+Content-Type: application/node.eks.aws
+
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: %s
+    apiServerEndpoint: %s
+    certificateAuthority: %s
+    cidr: %s
+
+--BOUNDARY--`, name, ep, ca, cidr)
+
+			encoded := base64.StdEncoding.EncodeToString([]byte(nodeConfig))
+			return &encoded
+		},
+	).(pulumi.StringPtrOutput)
+}

--- a/pkg/provider/aws/modules/network/airgap/airgap.go
+++ b/pkg/provider/aws/modules/network/airgap/airgap.go
@@ -22,6 +22,7 @@ type AirgapNetworkRequest struct {
 	TargetSubnetCIDR string
 	PublicSubnetCIDR string
 	SetAsAirgap      bool
+	ServiceEndpoints []string
 }
 
 type AirgapNetworkResources struct {
@@ -47,6 +48,18 @@ func (r AirgapNetworkRequest) CreateNetwork(ctx *pulumi.Context, mCtx *mc.Contex
 			result.VPCResources.VPC,
 			result.VPCResources.InternetGateway,
 			"public")
+	if err != nil {
+		return nil, err
+	}
+	// Create VPC endpoints for the public subnet
+	err = subnet.EndpointsRequest{
+		VPC:              result.VPCResources.VPC,
+		Subnets:          []*ec2.Subnet{result.PublicSubnet.Subnet},
+		RouteTables:      []*ec2.RouteTable{result.PublicSubnet.RouteTable},
+		Region:           r.Region,
+		Name:             r.Name,
+		ServiceEndpoints: r.ServiceEndpoints,
+	}.Create(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/aws/modules/network/network.go
+++ b/pkg/provider/aws/modules/network/network.go
@@ -125,7 +125,8 @@ func airgapNetworking(ctx *pulumi.Context, mCtx *mc.Context, args *NetworkArgs) 
 		AvailabilityZone: args.AZ,
 		PublicSubnetCIDR: cidrPublicSN,
 		TargetSubnetCIDR: cidrIntraSN,
-		SetAsAirgap:      args.AirgapPhaseConnectivity == OFF}.CreateNetwork(ctx, mCtx)
+		SetAsAirgap:      args.AirgapPhaseConnectivity == OFF,
+		ServiceEndpoints: args.ServiceEndpoints}.CreateNetwork(ctx, mCtx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/provider/aws/modules/network/standard/standard.go
+++ b/pkg/provider/aws/modules/network/standard/standard.go
@@ -119,6 +119,26 @@ func (r NetworkRequest) CreateNetwork(ctx *pulumi.Context) (*NetworkResources, e
 	if err != nil {
 		return nil, err
 	}
+	// Create VPC endpoints once for all public subnets
+	if len(publicSNResults) > 0 {
+		subnets := make([]*ec2.Subnet, len(publicSNResults))
+		routeTables := make([]*ec2.RouteTable, len(publicSNResults))
+		for i, snr := range publicSNResults {
+			subnets[i] = snr.Subnet
+			routeTables[i] = snr.RouteTable
+		}
+		err = subnet.EndpointsRequest{
+			VPC:              vpcResult.VPC,
+			Subnets:          subnets,
+			RouteTables:      routeTables,
+			Region:           r.Region,
+			Name:             r.Name,
+			ServiceEndpoints: r.ServiceEndpoints,
+		}.Create(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
 	// Manage Private Subnets
 	privateSNResults, err :=
 		r.managePrivateSubnets(r.MCtx, vpcResult.VPC, getNatGateways(publicSNResults), ctx, "private")
@@ -174,7 +194,6 @@ func (r NetworkRequest) managePublicSubnets(mCtx *mc.Context, vpc *ec2.Vpc,
 					Name:             fmt.Sprintf("%s%s%d", namePrefix, r.Name, i),
 					AddNatGateway:    r.checkIfNatGatewayRequired(i),
 					MapPublicIp:      r.MapPublicIp,
-					ServiceEndpoints:        r.ServiceEndpoints,
 				}
 			subnet, err := publicSNRequest.Create(ctx, mCtx)
 			if err != nil {

--- a/pkg/provider/aws/services/vpc/subnet/endpoints.go
+++ b/pkg/provider/aws/services/vpc/subnet/endpoints.go
@@ -1,0 +1,112 @@
+package subnet
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/ec2"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+var validEndpoints = map[string]bool{"s3": true, "ecr": true, "ssm": true}
+
+type EndpointsRequest struct {
+	VPC              *ec2.Vpc
+	Subnets          []*ec2.Subnet
+	RouteTables      []*ec2.RouteTable
+	Region           string
+	Name             string
+	ServiceEndpoints []string
+}
+
+func (r EndpointsRequest) Create(ctx *pulumi.Context) error {
+	if len(r.ServiceEndpoints) == 0 {
+		return nil
+	}
+	for _, e := range r.ServiceEndpoints {
+		if !validEndpoints[e] {
+			return fmt.Errorf("unknown VPC endpoint %q: accepted values are s3, ecr, ssm", e)
+		}
+	}
+
+	// Create interface-endpoint security group only when needed
+	needInterfaceSG := false
+	for _, e := range r.ServiceEndpoints {
+		if e == "ecr" || e == "ssm" {
+			needInterfaceSG = true
+			break
+		}
+	}
+	var sg *ec2.SecurityGroup
+	if needInterfaceSG {
+		var err error
+		sg, err = ec2.NewSecurityGroup(ctx,
+			fmt.Sprintf("%s-%s", "endpoints", r.Name),
+			&ec2.SecurityGroupArgs{
+				VpcId: r.VPC.ID(),
+				Ingress: ec2.SecurityGroupIngressArray{
+					&ec2.SecurityGroupIngressArgs{
+						Protocol:   pulumi.String("tcp"),
+						FromPort:   pulumi.Int(443),
+						ToPort:     pulumi.Int(443),
+						CidrBlocks: pulumi.StringArray{r.VPC.CidrBlock},
+					},
+				},
+			})
+		if err != nil {
+			return err
+		}
+	}
+
+	routeTableIds := make(pulumi.StringArray, len(r.RouteTables))
+	for i, rt := range r.RouteTables {
+		routeTableIds[i] = rt.ID()
+	}
+	subnetIds := make(pulumi.StringArray, len(r.Subnets))
+	for i, sn := range r.Subnets {
+		subnetIds[i] = sn.ID()
+	}
+
+	for _, e := range r.ServiceEndpoints {
+		switch e {
+		case "s3":
+			_, err := ec2.NewVpcEndpoint(ctx,
+				fmt.Sprintf("%s-%s", "endpoint-s3", r.Name),
+				&ec2.VpcEndpointArgs{
+					VpcId:           r.VPC.ID(),
+					ServiceName:     pulumi.Sprintf("com.amazonaws.%s.s3", r.Region),
+					VpcEndpointType: pulumi.String("Gateway"),
+					RouteTableIds:   routeTableIds,
+				})
+			if err != nil {
+				return err
+			}
+		case "ecr":
+			_, err := ec2.NewVpcEndpoint(ctx,
+				fmt.Sprintf("%s-%s", "endpoint-ecr", r.Name),
+				&ec2.VpcEndpointArgs{
+					VpcId:            r.VPC.ID(),
+					ServiceName:      pulumi.Sprintf("com.amazonaws.%s.ecr.dkr", r.Region),
+					VpcEndpointType:  pulumi.String("Interface"),
+					SubnetIds:        subnetIds,
+					SecurityGroupIds: pulumi.StringArray{sg.ID()},
+				})
+			if err != nil {
+				return err
+			}
+		case "ssm":
+			_, err := ec2.NewVpcEndpoint(ctx,
+				fmt.Sprintf("%s-%s", "endpoint-ssm", r.Name),
+				&ec2.VpcEndpointArgs{
+					VpcId:            r.VPC.ID(),
+					ServiceName:      pulumi.Sprintf("com.amazonaws.%s.ssm", r.Region),
+					VpcEndpointType:  pulumi.String("Interface"),
+					SubnetIds:        subnetIds,
+					SecurityGroupIds: pulumi.StringArray{sg.ID()},
+				})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/provider/aws/services/vpc/subnet/public.go
+++ b/pkg/provider/aws/services/vpc/subnet/public.go
@@ -18,7 +18,6 @@ type PublicSubnetRequest struct {
 	Name             string
 	AddNatGateway    bool
 	MapPublicIp      bool
-	ServiceEndpoints []string
 }
 
 type PublicSubnetResources struct {
@@ -91,11 +90,6 @@ func (r PublicSubnetRequest) Create(ctx *pulumi.Context, mCtx *mc.Context) (*Pub
 	if err != nil {
 		return nil, err
 	}
-	// Manage endpoints
-	err = endpoints(ctx, r.ServiceEndpoints, r.Name, r.Region, r.VPC, sn, rt)
-	if err != nil {
-		return nil, err
-	}
 	return &PublicSubnetResources{
 			Subnet:                sn,
 			RouteTable:            rt,
@@ -103,89 +97,4 @@ func (r PublicSubnetRequest) Create(ctx *pulumi.Context, mCtx *mc.Context) (*Pub
 			NatGateway:            n,
 			NatGatewayEip:         nEip},
 		nil
-}
-
-var validEndpoints = map[string]bool{"s3": true, "ecr": true, "ssm": true}
-
-func endpoints(ctx *pulumi.Context, endpointList []string, name, region string,
-	vpc *ec2.Vpc, sn *ec2.Subnet, rt *ec2.RouteTable) error {
-	if len(endpointList) == 0 {
-		return nil
-	}
-	for _, e := range endpointList {
-		if !validEndpoints[e] {
-			return fmt.Errorf("unknown VPC endpoint %q: accepted values are s3, ecr, ssm", e)
-		}
-	}
-	// Create interface-endpoint security group only when needed
-	needInterfaceSG := false
-	for _, e := range endpointList {
-		if e == "ecr" || e == "ssm" {
-			needInterfaceSG = true
-			break
-		}
-	}
-	var sg *ec2.SecurityGroup
-	if needInterfaceSG {
-		var err error
-		sg, err = ec2.NewSecurityGroup(ctx,
-			fmt.Sprintf("%s-%s", "endpoints", name),
-			&ec2.SecurityGroupArgs{
-				VpcId: vpc.ID(),
-				Ingress: ec2.SecurityGroupIngressArray{
-					&ec2.SecurityGroupIngressArgs{
-						Protocol:   pulumi.String("tcp"),
-						FromPort:   pulumi.Int(443),
-						ToPort:     pulumi.Int(443),
-						CidrBlocks: pulumi.StringArray{vpc.CidrBlock},
-					},
-				},
-			})
-		if err != nil {
-			return err
-		}
-	}
-	for _, e := range endpointList {
-		switch e {
-		case "s3":
-			_, err := ec2.NewVpcEndpoint(ctx,
-				fmt.Sprintf("%s-%s", "endpoint-s3", name),
-				&ec2.VpcEndpointArgs{
-					VpcId:           vpc.ID(),
-					ServiceName:     pulumi.Sprintf("com.amazonaws.%s.s3", region),
-					VpcEndpointType: pulumi.String("Gateway"),
-					RouteTableIds:   pulumi.StringArray{rt.ID()},
-				})
-			if err != nil {
-				return err
-			}
-		case "ecr":
-			_, err := ec2.NewVpcEndpoint(ctx,
-				fmt.Sprintf("%s-%s", "endpoint-ecr", name),
-				&ec2.VpcEndpointArgs{
-					VpcId:            vpc.ID(),
-					ServiceName:      pulumi.Sprintf("com.amazonaws.%s.ecr.dkr", region),
-					VpcEndpointType:  pulumi.String("Interface"),
-					SubnetIds:        pulumi.StringArray{sn.ID()},
-					SecurityGroupIds: pulumi.StringArray{sg.ID()},
-				})
-			if err != nil {
-				return err
-			}
-		case "ssm":
-			_, err := ec2.NewVpcEndpoint(ctx,
-				fmt.Sprintf("%s-%s", "endpoint-ssm", name),
-				&ec2.VpcEndpointArgs{
-					VpcId:            vpc.ID(),
-					ServiceName:      pulumi.Sprintf("com.amazonaws.%s.ssm", region),
-					VpcEndpointType:  pulumi.String("Interface"),
-					SubnetIds:        pulumi.StringArray{sn.ID()},
-					SecurityGroupIds: pulumi.StringArray{sg.ID()},
-				})
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }

--- a/tkn/infra-aws-eks.yaml
+++ b/tkn/infra-aws-eks.yaml
@@ -1,0 +1,301 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: infra-aws-eks
+  labels:
+    app.kubernetes.io/version: "1.0.0-dev"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, aws, eks
+    tekton.dev/displayName: "aws manager"
+    tekton.dev/platforms: "linux/amd64, linux/arm64"
+spec:
+  description: |
+    This task will provision / decomission an AWS EKS cluster
+
+    The output will give required information to connect within the remote provisioned cluster
+
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.secret-aws-credentials)
+    - name: cluster-info
+      emptyDir: {}
+
+  params:
+    # Credentials
+    - name: secret-aws-credentials
+      description: |
+        ocp secret holding the aws credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+          bucket: ${bucket}
+
+    # Mapt params
+    - name: id
+      description: identifier for the provisioned environment
+    - name: operation
+      description: operation to execute within the infrastructure. Current values (create, destroy)
+
+    # Secret result
+    # naming
+    - name: cluster-access-secret-name
+      type: string
+      default: "''"
+      description: |
+        Once the target is provisioned the config to connect is addded to a secret
+        check resutls. If this param is set the secret will be created with the name set
+        otherwise it will be created with a random name.
+    # ownership
+    - name: ownerKind
+      type: string
+      default: PipelineRun
+      description: |
+        The type of resource that should own the generated SpaceRequest.
+        Deletion of this resource will trigger deletion of the SpaceRequest.
+        Supported values: `PipelineRun`, `TaskRun`.
+    - name: ownerName
+      type: string
+      default: "''"
+      description: |
+        The name of the resource that should own the generated SpaceRequest.
+        This should either be passed the value of `$(context.pipelineRun.name)`
+        or `$(context.taskRun.name)` depending on the value of `ownerKind`.
+    - name: ownerUid
+      type: string
+      default: "''"
+      description: |
+        The uid of the resource that should own the generated SpaceRequest.
+        This should either be passed the value of `$(context.pipelineRun.uid)`
+        or `$(context.taskRun.uid)` depending on the value of `ownerKind`.
+
+    # EKS params
+    - name: k8s-version
+      description: EKS K8s cluster version (default "1.31")
+      default: '1.31'
+    - name: arch
+      description: Architecture for the machine. Allowed x86_64 or arm64 (default "x86_64")
+      default: 'x86_64'
+    - name: workers-desired
+      description: Worker nodes scaling desired size (default 1)
+      default: '1'
+    - name: workers-max
+      description: Worker nodes scaling maximum size (default 3)
+      default: '3'
+    - name: workers-min
+      description: Worker nodes scaling minimum size (default 1)
+      default: '1'
+    - name: addons
+      description: Comma-separated list of EKS addons to install (default "coredns,kube-proxy,vpc-cni,eks-pod-identity-agent,aws-ebs-csi-driver")
+      default: 'coredns,kube-proxy,vpc-cni,eks-pod-identity-agent,aws-ebs-csi-driver'
+    - name: load-balancer-controller
+      description: Install AWS Load Balancer Controller (default false)
+      default: 'false'
+
+    # Spot params
+    - name: spot
+      description: Check best spot option to spin the machine and will create resources on that region.
+      default: 'true'
+    - name: spot-eviction-tolerance
+      description: |
+        if spot is enable we can define the minimum tolerance level of eviction.
+        Allowed value are: lowest, low, medium, high or highest
+      default: 'lowest'
+    - name: spot-increase-rate
+      description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
+      default: '30'
+
+    # Metadata params
+    - name: tags
+      description: tags for the resources created on the providers
+      default: "''"
+
+    # Control params
+    - name: debug
+      description: |
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
+      default: 'false'
+    - name: force-destroy
+      description: |
+        If force-destroy is set the command will destroy even if there is a lock.
+        Allowed values: true, false
+      default: "false"
+    - name: keep-state
+      description: |
+        Keep Pulumi state files in S3 backend after successful destroy (by default, state files are removed). Only used when operation is destroy.
+        Allowed values: true, false
+      default: 'false'
+
+  results:
+    - name: cluster-access-secret
+      description: |
+        ocp secret holding the information to connect to the cluster
+
+          ---
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: ${name}
+          type: Opaque
+          data:
+            kubeconfig: ${kubeconfig}
+
+  steps:
+    - name: provisioner
+      image: quay.io/redhat-developer/mapt:v1.0.0-dev
+      imagePullPolicy: Always
+      env:
+        - name: HOME
+          value: /opt/mapt/run
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /opt/aws-credentials
+        - name: cluster-info
+          mountPath: /opt/cluster-info
+      script: |
+        #!/bin/sh
+
+        set -euo pipefail
+
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
+        export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
+        export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
+        export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
+        BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
+
+        if [[ $(params.operation) == "create"  ]]; then
+          if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then
+            echo "Parameter ownerName and ownerUid is recommended when creating instance"
+          fi
+        fi
+
+        # Run mapt
+        cmd="mapt aws eks $(params.operation) "
+        cmd+="--project-name mapt-eks-$(params.id) "
+        cmd+="--backed-url s3://${BUCKET}/mapt/eks/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
+        if [[ $(params.operation) == "create" ]]; then
+          cmd+="--conn-details-output /opt/cluster-info "
+          cmd+="--version $(params.k8s-version) "
+          cmd+="--arch $(params.arch) "
+          cmd+="--workers-desired $(params.workers-desired) "
+          cmd+="--workers-max $(params.workers-max) "
+          cmd+="--workers-min $(params.workers-min) "
+          cmd+="--addons $(params.addons) "
+          if [[ $(params.load-balancer-controller) == "true" ]]; then
+            cmd+="--load-balancer-controller "
+          fi
+          if [[ $(params.spot) == "true" ]]; then
+            cmd+="--spot --spot-eviction-tolerance $(params.spot-eviction-tolerance) --spot-increase-rate $(params.spot-increase-rate) "
+          fi
+          cmd+="--tags $(params.tags) "
+        fi
+
+        if [[ "$(params.operation)" == "destroy" ]]; then
+          if [[ "$(params.keep-state)" == "true" ]]; then
+            cmd+="--keep-state "
+          fi
+          if [[ "$(params.force-destroy)" == "true" ]]; then
+            cmd+="--force-destroy "
+          fi
+        fi
+
+        eval "${cmd}"
+
+      resources:
+        requests:
+          memory: "200Mi"
+          cpu: "100m"
+        limits:
+          memory: "600Mi"
+          cpu: "300m"
+    - name: cluster-info-secret
+      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      env:
+        - name: NAMESPACE
+          value: $(context.taskRun.namespace)
+        - name: OWNER_KIND
+          value: $(params.ownerKind)
+        - name: OWNER_NAME
+          value: $(params.ownerName)
+        - name: OWNER_UID
+          value: $(params.ownerUid)
+      volumeMounts:
+        - name: cluster-info
+          mountPath: /opt/cluster-info
+      workingDir: /opt/cluster-info
+      script: |
+        #!/bin/bash
+        set -eo pipefail
+        if [[ $(params.operation) == "create" ]]; then
+        export SECRETNAME="generateName: mapt-aws-eks-"
+        if [[ $(params.cluster-access-secret-name) != "" ]]; then
+          export SECRETNAME="name: $(params.cluster-access-secret-name)"
+        fi
+        cat <<EOF > cluster-info.yaml
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          $SECRETNAME
+          namespace: $NAMESPACE
+        EOF
+        if [[ "$OWNER_NAME" != "" && "$OWNER_UID" != "" ]]; then
+        cat <<EOF >> cluster-info.yaml
+          ownerReferences:
+          - apiVersion: tekton.dev/v1
+            kind: $OWNER_KIND
+            name: $OWNER_NAME
+            uid: $OWNER_UID
+        EOF
+        fi
+        cat <<EOF >> cluster-info.yaml
+        type: Opaque
+        data:
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
+        EOF
+
+        if [[ $(params.debug) == "true" ]]; then
+          cat /opt/cluster-info/*
+        fi
+
+        NAME=$(oc create -f cluster-info.yaml -o=jsonpath='{.metadata.name}')
+        echo -n "${NAME}" | tee $(results.cluster-access-secret.path)
+        fi

--- a/tkn/infra-azure-aks.yaml
+++ b/tkn/infra-azure-aks.yaml
@@ -82,8 +82,8 @@ spec:
 
     # AKS params
     - name: k8s-version
-      description: AKS K8s cluster version (default "1.30")
-      default: '1.30'
+      description: AKS K8s cluster version (default "1.31")
+      default: '1.31'
     - name: only-system-pool
       description: if we do not need bunch of resources we can run only the systempool. More info https://learn.microsoft.com/es-es/azure/aks/use-system-pools?tabs=azure-cli#system-and-user-node-pools. (default false)
       default: 'false'
@@ -226,7 +226,7 @@ spec:
         - name: OWNER_NAME
           value: $(params.ownerName)
         - name: OWNER_UID
-          value: $(params.ownerUid)  
+          value: $(params.ownerUid)
       volumeMounts:
         - name: cluster-info
           mountPath: /opt/cluster-info
@@ -264,7 +264,7 @@ spec:
         if [[ $(params.debug) == "true" ]]; then
           cat /opt/cluster-info/*
         fi
-        
+
         NAME=$(oc create -f cluster-info.yaml -o=jsonpath='{.metadata.name}')
-        echo -n "${NAME}" | tee $(results.cluster-access-secret.path)   
+        echo -n "${NAME}" | tee $(results.cluster-access-secret.path)
         fi

--- a/tkn/template/infra-aws-eks.yaml
+++ b/tkn/template/infra-aws-eks.yaml
@@ -1,0 +1,300 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: infra-aws-eks
+  labels:
+    app.kubernetes.io/version: "<VERSION>"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, aws, eks
+    tekton.dev/displayName: "aws manager"
+    tekton.dev/platforms: "linux/amd64, linux/arm64"
+spec:
+  description: |
+    This task will provision / decomission an AWS EKS cluster
+
+    The output will give required information to connect within the remote provisioned cluster
+
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.secret-aws-credentials)
+    - name: cluster-info
+      emptyDir: {}
+
+  params:
+    # Credentials
+    - name: secret-aws-credentials
+      description: |
+        ocp secret holding the aws credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+          bucket: ${bucket}
+    # Mapt params
+    - name: id
+      description: identifier for the provisioned environment
+    - name: operation
+      description: operation to execute within the infrastructure. Current values (create, destroy)
+
+    # Secret result
+    # naming
+    - name: cluster-access-secret-name
+      type: string
+      default: "''"
+      description: |
+        Once the target is provisioned the config to connect is addded to a secret
+        check resutls. If this param is set the secret will be created with the name set
+        otherwise it will be created with a random name.
+    # ownership
+    - name: ownerKind
+      type: string
+      default: PipelineRun
+      description: |
+        The type of resource that should own the generated SpaceRequest.
+        Deletion of this resource will trigger deletion of the SpaceRequest.
+        Supported values: `PipelineRun`, `TaskRun`.
+    - name: ownerName
+      type: string
+      default: "''"
+      description: |
+        The name of the resource that should own the generated SpaceRequest.
+        This should either be passed the value of `$(context.pipelineRun.name)`
+        or `$(context.taskRun.name)` depending on the value of `ownerKind`.
+    - name: ownerUid
+      type: string
+      default: "''"
+      description: |
+        The uid of the resource that should own the generated SpaceRequest.
+        This should either be passed the value of `$(context.pipelineRun.uid)`
+        or `$(context.taskRun.uid)` depending on the value of `ownerKind`.
+
+    # EKS params
+    - name: k8s-version
+      description: EKS K8s cluster version (default "1.31")
+      default: '1.31'
+    - name: arch
+      description: Architecture for the machine. Allowed x86_64 or arm64 (default "x86_64")
+      default: 'x86_64'
+    - name: workers-desired
+      description: Worker nodes scaling desired size (default 1)
+      default: '1'
+    - name: workers-max
+      description: Worker nodes scaling maximum size (default 3)
+      default: '3'
+    - name: workers-min
+      description: Worker nodes scaling minimum size (default 1)
+      default: '1'
+    - name: addons
+      description: Comma-separated list of EKS addons to install (default "coredns,kube-proxy,vpc-cni,eks-pod-identity-agent,aws-ebs-csi-driver")
+      default: 'coredns,kube-proxy,vpc-cni,eks-pod-identity-agent,aws-ebs-csi-driver'
+    - name: load-balancer-controller
+      description: Install AWS Load Balancer Controller (default false)
+      default: 'false'
+
+    # Spot params
+    - name: spot
+      description: Check best spot option to spin the machine and will create resources on that region.
+      default: 'true'
+    - name: spot-eviction-tolerance
+      description: |
+        if spot is enable we can define the minimum tolerance level of eviction.
+        Allowed value are: lowest, low, medium, high or highest
+      default: 'lowest'
+    - name: spot-increase-rate
+      description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
+      default: '30'
+
+    # Metadata params
+    - name: tags
+      description: tags for the resources created on the providers
+      default: "''"
+
+    # Control params
+    - name: debug
+      description: |
+        Warning setting this param to true exposes partially masked credentials
+
+        The parameter is intended to add verbosity on the task execution and also print masked credentials
+        (showing first and last character with *** in the middle) on stdout to help with debugging
+      default: 'false'
+    - name: force-destroy
+      description: |
+        If force-destroy is set the command will destroy even if there is a lock.
+        Allowed values: true, false
+      default: "false"
+    - name: keep-state
+      description: |
+        Keep Pulumi state files in S3 backend after successful destroy (by default, state files are removed). Only used when operation is destroy.
+        Allowed values: true, false
+      default: 'false'
+
+  results:
+    - name: cluster-access-secret
+      description: |
+        ocp secret holding the information to connect to the cluster
+
+          ---
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: ${name}
+          type: Opaque
+          data:
+            kubeconfig: ${kubeconfig}
+
+  steps:
+    - name: provisioner
+      image: <IMAGE>
+      imagePullPolicy: Always
+      env:
+        - name: HOME
+          value: /opt/mapt/run
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /opt/aws-credentials
+        - name: cluster-info
+          mountPath: /opt/cluster-info
+      script: |
+        #!/bin/sh
+
+        set -euo pipefail
+
+        # Function to mask credentials (show first and last char, hide middle)
+        mask_credential() {
+          local cred="$1"
+          local len=${#cred}
+          if [ $len -le 2 ]; then
+            echo "***"
+          else
+            echo "${cred:0:1}***${cred: -1}"
+          fi
+        }
+
+        # Credentials - set these BEFORE enabling debug mode
+        export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
+        export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
+        export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
+        BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        # If debug add verbosity and print masked credentials
+        if [[ $(params.debug) == "true" ]]; then
+          echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
+          echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
+          echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          echo "BUCKET=$BUCKET"
+          set -xeuo pipefail
+        fi
+
+        if [[ $(params.operation) == "create"  ]]; then
+          if [[ $(params.ownerName) == "" || $(params.ownerUid) == "" ]]; then
+            echo "Parameter ownerName and ownerUid is recommended when creating instance"
+          fi
+        fi
+
+        # Run mapt
+        cmd="mapt aws eks $(params.operation) "
+        cmd+="--project-name mapt-eks-$(params.id) "
+        cmd+="--backed-url s3://${BUCKET}/mapt/eks/$(params.id) "
+
+        if [[ $(params.debug) == "true" ]]; then
+          cmd+="--debug "
+        fi
+
+        if [[ $(params.operation) == "create" ]]; then
+          cmd+="--conn-details-output /opt/cluster-info "
+          cmd+="--version $(params.k8s-version) "
+          cmd+="--arch $(params.arch) "
+          cmd+="--workers-desired $(params.workers-desired) "
+          cmd+="--workers-max $(params.workers-max) "
+          cmd+="--workers-min $(params.workers-min) "
+          cmd+="--addons $(params.addons) "
+          if [[ $(params.load-balancer-controller) == "true" ]]; then
+            cmd+="--load-balancer-controller "
+          fi
+          if [[ $(params.spot) == "true" ]]; then
+            cmd+="--spot --spot-eviction-tolerance $(params.spot-eviction-tolerance) --spot-increase-rate $(params.spot-increase-rate) "
+          fi
+          cmd+="--tags $(params.tags) "
+        fi
+
+        if [[ "$(params.operation)" == "destroy" ]]; then
+          if [[ "$(params.keep-state)" == "true" ]]; then
+            cmd+="--keep-state "
+          fi
+          if [[ "$(params.force-destroy)" == "true" ]]; then
+            cmd+="--force-destroy "
+          fi
+        fi
+
+        eval "${cmd}"
+
+      resources:
+        requests:
+          memory: "200Mi"
+          cpu: "100m"
+        limits:
+          memory: "600Mi"
+          cpu: "300m"
+    - name: cluster-info-secret
+      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      env:
+        - name: NAMESPACE
+          value: $(context.taskRun.namespace)
+        - name: OWNER_KIND
+          value: $(params.ownerKind)
+        - name: OWNER_NAME
+          value: $(params.ownerName)
+        - name: OWNER_UID
+          value: $(params.ownerUid)
+      volumeMounts:
+        - name: cluster-info
+          mountPath: /opt/cluster-info
+      workingDir: /opt/cluster-info
+      script: |
+        #!/bin/bash
+        set -eo pipefail
+        if [[ $(params.operation) == "create" ]]; then
+        export SECRETNAME="generateName: mapt-aws-eks-"
+        if [[ $(params.cluster-access-secret-name) != "" ]]; then
+          export SECRETNAME="name: $(params.cluster-access-secret-name)"
+        fi
+        cat <<EOF > cluster-info.yaml
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          $SECRETNAME
+          namespace: $NAMESPACE
+        EOF
+        if [[ "$OWNER_NAME" != "" && "$OWNER_UID" != "" ]]; then
+        cat <<EOF >> cluster-info.yaml
+          ownerReferences:
+          - apiVersion: tekton.dev/v1
+            kind: $OWNER_KIND
+            name: $OWNER_NAME
+            uid: $OWNER_UID
+        EOF
+        fi
+        cat <<EOF >> cluster-info.yaml
+        type: Opaque
+        data:
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
+        EOF
+
+        if [[ $(params.debug) == "true" ]]; then
+          cat /opt/cluster-info/*
+        fi
+
+        NAME=$(oc create -f cluster-info.yaml -o=jsonpath='{.metadata.name}')
+        echo -n "${NAME}" | tee $(results.cluster-access-secret.path)
+        fi

--- a/tkn/template/infra-azure-aks.yaml
+++ b/tkn/template/infra-azure-aks.yaml
@@ -82,8 +82,8 @@ spec:
 
     # AKS params
     - name: k8s-version
-      description: AKS K8s cluster version (default "1.30")
-      default: '1.30'
+      description: AKS K8s cluster version (default "1.31")
+      default: '1.31'
     - name: only-system-pool
       description: if we do not need bunch of resources we can run only the systempool. More info https://learn.microsoft.com/es-es/azure/aks/use-system-pools?tabs=azure-cli#system-and-user-node-pools. (default false)
       default: 'false'
@@ -115,7 +115,7 @@ spec:
         The parameter is intended to add verbosity on the task execution and also print masked credentials
         (showing first and last character with *** in the middle) on stdout to help with debugging
       default: 'false'
-    
+
   results:
     - name: cluster-access-secret
       description: |
@@ -184,7 +184,7 @@ spec:
             echo "Parameter ownerName and ownerUid is recommended when creating instance"
           fi
         fi
-        
+
         # Run mapt
         cmd="mapt azure aks $(params.operation) "
         cmd+="--project-name mapt-aks-$(params.id) "
@@ -264,7 +264,7 @@ spec:
         if [[ $(params.debug) == "true" ]]; then
           cat /opt/cluster-info/*
         fi
-        
+
         NAME=$(oc create -f cluster-info.yaml -o=jsonpath='{.metadata.name}')
-        echo -n "${NAME}" | tee $(results.cluster-access-secret.path)   
+        echo -n "${NAME}" | tee $(results.cluster-access-secret.path)
         fi


### PR DESCRIPTION
## Summary

### Self-managed node groups with spot support
- Replace EKS managed node group with a self-managed Auto Scaling Group (ASG) for direct spot price control
- Add `spotPrice` parameter to set maximum bid for spot instances
- Use API authentication mode with access entries for self-managed node authentication

### Cluster reliability fixes
- Add service CIDR to nodeadm `NodeConfig` (required by AL2023 for proper pod networking without `DescribeCluster` API calls)
- Deploy addons in phased dependency order: infrastructure addons (vpc-cni, kube-proxy, eks-pod-identity-agent) → coredns → remaining addons (aws-ebs-csi-driver)
- Add `WaitForCapacityTimeout`, `HealthCheckType`, and `HealthCheckGracePeriod` to ASG so Pulumi waits for nodes to be InService before deploying addons
- Add `ResolveConflictsOnCreate` and extended timeouts to all EKS addons
- Make LB controller depend on coredns for DNS resolution
- Remove unused NAT gateway (`NatGatewayModeNone`) since EKS uses only public subnets

### VPC endpoint extraction
- Extract VPC endpoint creation from per-subnet code into a shared `EndpointsRequest` module
- Endpoints are created once per VPC across all public subnets (required for multi-AZ EKS — AWS allows only one S3 gateway endpoint per VPC)
- Integrates with the opt-in `ServiceEndpoints` pattern from #754

### Other
- Remove AWS CLI dependency from EKS cluster creation
- Add resource tags to all EKS-specific AWS resources (cluster, IAM roles, OIDC provider, addons, ASG, etc.)
- Extend EKS documentation

Resolves #499