### PR TITLE
fix(aws): remove trailing dash from RHEL AI AMI name patterns

### DIFF
--- a/pkg/provider/aws/action/rhel-ai/constants.go
+++ b/pkg/provider/aws/action/rhel-ai/constants.go
@@ -15,8 +15,8 @@ var (
 
 	// amiProduct     = "Red Hat Enterprise Linux"
 	amiProduct = "Linux/UNIX"
-	amiV1Regex = "rhel-ai-nvidia-aws-%s-*"
-	amiRegex   = "rhel-ai-%s-aws-%s-*"
+	amiV1Regex = "rhel-ai-nvidia-aws-%s*"
+	amiRegex   = "rhel-ai-%s-aws-%s*"
 	amiOwner   = "610952687893"
 	// amiOwnerSelf   = "self"
 	amiArch        = "x86_64"


### PR DESCRIPTION
## Summary

- Remove literal `-` before wildcard `*` in RHEL AI AMI name patterns
- `rhel-ai-%s-aws-%s-*` → `rhel-ai-%s-aws-%s*`
- `rhel-ai-nvidia-aws-%s-*` → `rhel-ai-nvidia-aws-%s*`

Current RHEL AI AMIs (3.0.0, 3.2.0, 3.3.0, 3.4.0-ea.1) have no build suffix after the version, so the trailing `-*` pattern fails to match. This aligns with the Fedora and Mac providers which already use `%s*` without a dash.

Fixes #772