### PR TITLE
fix(tkn): param accelerator was ignored with compute-sizes specified

### DIFF
--- a/tkn/infra-azure-rhel-ai.yaml
+++ b/tkn/infra-azure-rhel-ai.yaml
@@ -222,12 +222,11 @@ spec:
 
           if [[ "$(params.compute-sizes)" != "" ]]; then
             cmd+="--compute-sizes '$(params.compute-sizes)' "
-          else
-            cmd+="--accelerator '$(params.accelerator)' "
           fi
           if [[ "$(params.custom-image)" != "" ]]; then
             cmd+="--custom-image '$(params.custom-image)' "
           else
+            cmd+="--accelerator '$(params.accelerator)' "
             cmd+="--version '$(params.version)' "
           fi
 

--- a/tkn/template/infra-azure-rhel-ai.yaml
+++ b/tkn/template/infra-azure-rhel-ai.yaml
@@ -222,12 +222,11 @@ spec:
 
           if [[ "$(params.compute-sizes)" != "" ]]; then
             cmd+="--compute-sizes '$(params.compute-sizes)' "
-          else
-            cmd+="--accelerator '$(params.accelerator)' "
           fi
           if [[ "$(params.custom-image)" != "" ]]; then
             cmd+="--custom-image '$(params.custom-image)' "
           else
+            cmd+="--accelerator '$(params.accelerator)' "
             cmd+="--version '$(params.version)' "
           fi
 


### PR DESCRIPTION
For spot machines with compute sizes specified, mapt chose CUDA image even though accelerator was set to ROCm

Tested with both CUDA and ROCm