### PR TITLE
feat(release): automate binary release on tag push

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -53,6 +53,16 @@ jobs:
           else
             echo "ARCH_TYPE=amd64" >> $GITHUB_ENV
           fi
+      - name: Set version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+      - name: Log in quay.io
+        if: github.event_name == 'push'
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_PASSWORD }}
       - name: Build image for PR
         if: github.event_name == 'pull_request'
         env:
@@ -61,16 +71,30 @@ jobs:
         run: |
           make oci-build-${{ env.ARCH_TYPE }}
           make oci-save-${{ env.ARCH_TYPE }}
-      - name: Build and Push image for Release
-        if: github.event_name == 'push'
-        run: |
-          make oci-build-${{ env.ARCH_TYPE }}
-          make oci-save-${{ env.ARCH_TYPE }}
-      - name: Upload mapt artifacts for PR
+      - name: Upload mapt OCI artifacts for PR
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mapt-${{ env.ARCH_TYPE }}
           path: mapt*
+      - name: Build and push arch image
+        if: github.event_name == 'push'
+        run: |
+          make oci-build-${{ env.ARCH_TYPE }}
+          make oci-push-${{ env.ARCH_TYPE }}
+      - name: Extract binary from image
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          IMAGE=quay.io/redhat-developer/mapt:v${VERSION:-1.0.0-dev}-${{ env.ARCH_TYPE }}
+          container=$(podman create ${IMAGE})
+          podman cp ${container}:/usr/local/bin/mapt ./mapt-linux-${{ env.ARCH_TYPE }}
+          podman rm ${container}
+      - name: Upload binary artifact
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mapt-linux-${{ env.ARCH_TYPE }}
+          path: mapt-linux-${{ env.ARCH_TYPE }}
   combine-artifacts:
     name: combine-artifacts
     needs: build-and-upload
@@ -98,21 +122,34 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Download mapt oci flatten images
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: mapt-*         
-        
+      - name: Set version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
       - name: Log in quay.io
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_IO_USERNAME }}
           password: ${{ secrets.QUAY_IO_PASSWORD }}
-
-      - name: Push image for Release
-        if: github.event_name == 'push'
-        run: |
-          make oci-load
-          make oci-push
+      - name: Push manifest
+        run: make oci-push-manifest
+  release:
+    name: release
+    needs: [build-and-upload, push]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Download binary artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: mapt-linux-*
+          merge-multiple: true
+      - name: Create checksums
+        run: sha256sum mapt-linux-* > mapt-checksums.txt
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: gh release create "$TAG" mapt-linux-* mapt-checksums.txt --generate-notes

--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,18 @@ oci-load:
 
 # Push the docker image
 .PHONY: oci-push
-oci-push:
-	${CONTAINER_MANAGER} push $(IMG)-arm64
+oci-push: oci-push-amd64 oci-push-arm64 oci-push-manifest
+
+.PHONY: oci-push-amd64
+oci-push-amd64:
 	${CONTAINER_MANAGER} push $(IMG)-amd64
+
+.PHONY: oci-push-arm64
+oci-push-arm64:
+	${CONTAINER_MANAGER} push $(IMG)-arm64
+
+.PHONY: oci-push-manifest
+oci-push-manifest:
 	${CONTAINER_MANAGER} manifest create $(IMG)
 	${CONTAINER_MANAGER} manifest add $(IMG) docker://$(IMG)-arm64
 	${CONTAINER_MANAGER} manifest add $(IMG) docker://$(IMG)-amd64


### PR DESCRIPTION
The release process was manual before. This automates it on tag push.

Each matrix runner now extracts the mapt binary from the built container image using podman cp and uploads it as mapt-linux-amd64 or mapt-linux-arm64. A new release job picks those up, generates a sha256 checksums file, and creates a GitHub Release with everything attached.

The flattened OCI tarball artifacts are gone. Instead, each runner pushes its own arch image directly, and the manifest job stitches them together. Three new Makefile targets support this: oci-push-amd64, oci-push-arm64, and oci-push-manifest.

Signed-off-by: Rishabh Kothari <rkothari@redhat.com>