### PR TITLE
add `--disk-size` flag for setting custom disk size for provisioned machine

### DIFF
--- a/cmd/mapt/cmd/aws/hosts/windows.go
+++ b/cmd/mapt/cmd/aws/hosts/windows.go
@@ -76,6 +76,7 @@ func getWindowsCreate() *cobra.Command {
 					AMIOwner:         viper.GetString(amiOwner),
 					AMILang:          viper.GetString(amiLang),
 					AMIKeepCopy:      viper.IsSet(amiKeepCopy),
+					ComputeRequest:   params.ComputeRequestArgs(),
 					Spot:             params.SpotArgs(),
 					Airgap:           viper.IsSet(airgap),
 					Timeout:          viper.GetString(params.Timeout),
@@ -93,6 +94,7 @@ func getWindowsCreate() *cobra.Command {
 	flagSet.Bool(airgap, false, airgapDesc)
 	flagSet.StringP(params.Timeout, "", "", params.TimeoutDesc)
 	flagSet.Bool(amiKeepCopy, false, amiKeepCopyDesc)
+	params.AddComputeRequestFlags(flagSet)
 	params.AddSpotFlags(flagSet)
 	params.AddGHActionsFlags(flagSet)
 	params.AddCirrusFlags(flagSet)

--- a/cmd/mapt/cmd/params/params.go
+++ b/cmd/mapt/cmd/params/params.go
@@ -65,6 +65,9 @@ const (
 	nestedVirtDesc      string = "Use cloud instance that has nested virtualization support"
 	computeSizes        string = "compute-sizes"
 	computeSizesDesc    string = "Comma seperated list of sizes for the machines to be requested. If set this takes precedence over compute by args"
+	diskSize            string = "disk-size"
+	diskSizeDesc        string = "Disk size in GB for the cloud instance"
+	diskSizeDefault     int    = 200
 
 	CreateCmdName  string = "create"
 	DestroyCmdName string = "destroy"
@@ -183,10 +186,11 @@ func AddComputeRequestFlags(fs *pflag.FlagSet) {
 	fs.Int32P(memory, "", 64, memoryDesc)
 	fs.BoolP(nestedVirt, "", false, nestedVirtDesc)
 	fs.StringSliceP(computeSizes, "", []string{}, computeSizesDesc)
+	fs.IntP(diskSize, "", diskSizeDefault, diskSizeDesc)
 }
 
 func ComputeRequestArgs() *cr.ComputeRequestArgs {
-	return &cr.ComputeRequestArgs{
+	cra := &cr.ComputeRequestArgs{
 		CPUs:            viper.GetInt32(cpus),
 		GPUs:            viper.GetInt32(gpus),
 		GPUManufacturer: viper.GetString(gpuManufacturer),
@@ -196,6 +200,11 @@ func ComputeRequestArgs() *cr.ComputeRequestArgs {
 		NestedVirt:   viper.GetBool(ProfileSNC) || viper.GetBool(nestedVirt),
 		ComputeSizes: viper.GetStringSlice(computeSizes),
 	}
+	if viper.IsSet(diskSize) {
+		ds := viper.GetInt(diskSize)
+		cra.DiskSize = &ds
+	}
+	return cra
 }
 
 func AddCommonFlags(fs *pflag.FlagSet) {

--- a/pkg/provider/api/compute-request/compute-request.go
+++ b/pkg/provider/api/compute-request/compute-request.go
@@ -31,6 +31,8 @@ type ComputeRequestArgs struct {
 	// In case we want an specific type / size
 	// we can set them directly
 	ComputeSizes []string
+	// Disk size in GB, nil means use provider default
+	DiskSize *int
 }
 
 type ComputeSelector interface {

--- a/pkg/provider/aws/action/fedora/fedora.go
+++ b/pkg/provider/aws/action/fedora/fedora.go
@@ -54,6 +54,7 @@ type fedoraRequest struct {
 	serviceEndpoints []string
 	allocationData *allocation.AllocationResult
 	airgap         *bool
+	diskSize       *int
 	// internal management
 	// For airgap scenario there is an orchestation of
 	// a phase with connectivity on the machine (allowing bootstraping)
@@ -82,13 +83,14 @@ func Create(mCtxArgs *mc.ContextArgs, args *FedoraArgs) (err error) {
 	// Compose request
 	prefix := util.If(len(args.Prefix) > 0, args.Prefix, "main")
 	r := fedoraRequest{
-		mCtx:      mCtx,
-		prefix:    &prefix,
-		version:   &args.Version,
-		arch:      &args.Arch,
-		timeout:   &args.Timeout,
+		mCtx:             mCtx,
+		prefix:           &prefix,
+		version:          &args.Version,
+		arch:             &args.Arch,
+		timeout:          &args.Timeout,
 		serviceEndpoints: args.ServiceEndpoints,
-		airgap:    &args.Airgap}
+		airgap:           &args.Airgap,
+		diskSize:         args.ComputeRequest.DiskSize}
 	if args.Spot != nil {
 		r.spot = args.Spot.Spot
 	}
@@ -226,6 +228,10 @@ func (r *fedoraRequest) deploy(ctx *pulumi.Context) error {
 		return err
 	}
 
+	effectiveDiskSize := diskSize
+	if r.diskSize != nil {
+		effectiveDiskSize = *r.diskSize
+	}
 	cr := compute.ComputeRequest{
 		MCtx:             r.mCtx,
 		Prefix:           *r.prefix,
@@ -237,7 +243,7 @@ func (r *fedoraRequest) deploy(ctx *pulumi.Context) error {
 		UserDataAsBase64: userDataB64,
 		SecurityGroups:   securityGroups,
 		InstaceTypes:     r.allocationData.InstanceTypes,
-		DiskSize:         &diskSize,
+		DiskSize:         &effectiveDiskSize,
 		Airgap:           *r.airgap,
 		LB:               nw.LoadBalancer,
 		Eip:              nw.Eip,

--- a/pkg/provider/aws/action/kind/kind.go
+++ b/pkg/provider/aws/action/kind/kind.go
@@ -37,6 +37,7 @@ type kindRequest struct {
 	serviceEndpoints  []string
 	allocationData    *allocation.AllocationResult
 	extraPortMappings []utilKind.PortMapping
+	diskSize          *int
 }
 
 func (r *kindRequest) validate() error {
@@ -65,7 +66,8 @@ func Create(mCtxArgs *mc.ContextArgs, args *utilKind.KindArgs) (kr *utilKind.Kin
 		arch:              &args.Arch,
 		timeout:           &args.Timeout,
 		serviceEndpoints:  args.ServiceEndpoints,
-		extraPortMappings: args.ExtraPortMappings}
+		extraPortMappings: args.ExtraPortMappings,
+		diskSize:          args.ComputeRequest.DiskSize}
 	if args.Spot != nil {
 		r.spot = args.Spot.Spot
 	}
@@ -188,6 +190,10 @@ func (r *kindRequest) deploy(ctx *pulumi.Context) error {
 	lbTargetGroups := []int{22, utilKind.PortAPI, utilKind.PortHTTP, utilKind.PortHTTPS}
 	lbTargetGroups = append(lbTargetGroups, extraHostPorts...)
 
+	effectiveDiskSize := diskSize
+	if r.diskSize != nil {
+		effectiveDiskSize = *r.diskSize
+	}
 	cr := compute.ComputeRequest{
 		MCtx:             r.mCtx,
 		Prefix:           *r.prefix,
@@ -199,7 +205,7 @@ func (r *kindRequest) deploy(ctx *pulumi.Context) error {
 		UserDataAsBase64: udB64,
 		SecurityGroups:   securityGroups,
 		InstaceTypes:     r.allocationData.InstanceTypes,
-		DiskSize:         &diskSize,
+		DiskSize:         &effectiveDiskSize,
 		LB:               nw.LoadBalancer,
 		Eip:              nw.Eip,
 		LBTargetGroups:   lbTargetGroups,

--- a/pkg/provider/aws/action/rhel-ai/rhelai.go
+++ b/pkg/provider/aws/action/rhel-ai/rhelai.go
@@ -31,14 +31,15 @@ import (
 )
 
 type rhelAIRequest struct {
-	mCtx           *mc.Context
-	prefix         *string
-	amiName        *string
-	arch           *string
-	spot           bool
-	timeout        *string
+	mCtx             *mc.Context
+	prefix           *string
+	amiName          *string
+	arch             *string
+	spot             bool
+	timeout          *string
 	serviceEndpoints []string
-	allocationData *allocation.AllocationResult
+	allocationData   *allocation.AllocationResult
+	diskSize         *int
 }
 
 func (r *rhelAIRequest) validate() error {
@@ -66,12 +67,13 @@ func Create(mCtxArgs *mc.ContextArgs, args *apiRHELAI.RHELAIArgs) (err error) {
 	}
 	prefix := util.If(len(args.Prefix) > 0, args.Prefix, "main")
 	r := rhelAIRequest{
-		mCtx:      mCtx,
-		prefix:    &prefix,
-		amiName:   &amiName,
-		arch:      &args.Arch,
-		timeout:   &args.Timeout,
-		serviceEndpoints: args.ServiceEndpoints}
+		mCtx:             mCtx,
+		prefix:           &prefix,
+		amiName:          &amiName,
+		arch:             &args.Arch,
+		timeout:          &args.Timeout,
+		serviceEndpoints: args.ServiceEndpoints,
+		diskSize:         args.ComputeRequest.DiskSize}
 	if args.Spot != nil {
 		r.spot = args.Spot.Spot
 	}
@@ -180,6 +182,10 @@ func (r *rhelAIRequest) deploy(ctx *pulumi.Context) error {
 	if err != nil {
 		return err
 	}
+	effectiveDiskSize := diskSize
+	if r.diskSize != nil {
+		effectiveDiskSize = *r.diskSize
+	}
 	cr := compute.ComputeRequest{
 		MCtx:           r.mCtx,
 		Prefix:         *r.prefix,
@@ -190,7 +196,7 @@ func (r *rhelAIRequest) deploy(ctx *pulumi.Context) error {
 		KeyResources:   keyResources,
 		SecurityGroups: securityGroups,
 		InstaceTypes:   r.allocationData.InstanceTypes,
-		DiskSize:       &diskSize,
+		DiskSize:       &effectiveDiskSize,
 		LB:             nw.LoadBalancer,
 		Eip:            nw.Eip,
 		LBTargetGroups: []int{22}}

--- a/pkg/provider/aws/action/rhel/rhel.go
+++ b/pkg/provider/aws/action/rhel/rhel.go
@@ -59,6 +59,7 @@ type rhelRequest struct {
 	serviceEndpoints []string
 	allocationData *allocation.AllocationResult
 	airgap         *bool
+	diskSize       *int
 	// internal management
 	// For airgap scenario there is an orchestation of
 	// a phase with connectivity on the machine (allowing bootstraping)
@@ -87,16 +88,17 @@ func Create(mCtxArgs *mc.ContextArgs, args *RHELArgs) (err error) {
 	// Compose request
 	prefix := util.If(len(args.Prefix) > 0, args.Prefix, "main")
 	r := rhelRequest{
-		mCtx:         mCtx,
-		prefix:       &prefix,
-		version:      &args.Version,
-		arch:         &args.Arch,
-		timeout:      &args.Timeout,
-		subsUsername: &args.SubsUsername,
-		subsUserpass: &args.SubsUserpass,
-		profileSNC:   &args.ProfileSNC,
-		serviceEndpoints:    args.ServiceEndpoints,
-		airgap:       &args.Airgap}
+		mCtx:             mCtx,
+		prefix:           &prefix,
+		version:          &args.Version,
+		arch:             &args.Arch,
+		timeout:          &args.Timeout,
+		subsUsername:     &args.SubsUsername,
+		subsUserpass:     &args.SubsUserpass,
+		profileSNC:       &args.ProfileSNC,
+		serviceEndpoints: args.ServiceEndpoints,
+		airgap:           &args.Airgap,
+		diskSize:         args.ComputeRequest.DiskSize}
 	if args.Spot != nil {
 		r.spot = args.Spot.Spot
 	}
@@ -237,6 +239,10 @@ func (r *rhelRequest) deploy(ctx *pulumi.Context) error {
 		return err
 	}
 
+	effectiveDiskSize := diskSize
+	if r.diskSize != nil {
+		effectiveDiskSize = *r.diskSize
+	}
 	cr := compute.ComputeRequest{
 		MCtx:             r.mCtx,
 		Prefix:           *r.prefix,
@@ -248,7 +254,7 @@ func (r *rhelRequest) deploy(ctx *pulumi.Context) error {
 		KeyResources:     keyResources,
 		SecurityGroups:   securityGroups,
 		InstaceTypes:     r.allocationData.InstanceTypes,
-		DiskSize:         &diskSize,
+		DiskSize:         &effectiveDiskSize,
 		Airgap:           *r.airgap,
 		LB:               nw.LoadBalancer,
 		Eip:              nw.Eip,

--- a/pkg/provider/aws/action/snc/snc.go
+++ b/pkg/provider/aws/action/snc/snc.go
@@ -46,6 +46,7 @@ type openshiftSNCRequest struct {
 	serviceEndpoints        []string
 	allocationData          *allocation.AllocationResult
 	profiles                []string
+	diskSize                *int
 }
 
 func (r *openshiftSNCRequest) validate() error {
@@ -81,7 +82,8 @@ func Create(mCtxArgs *mc.ContextArgs, args *apiSNC.SNCArgs) (_ *apiSNC.SNCResult
 		pullSecretFile:          &args.PullSecretFile,
 		timeout:                 &args.Timeout,
 		serviceEndpoints:        args.ServiceEndpoints,
-		profiles:                args.Profiles}
+		profiles:                args.Profiles,
+		diskSize:                args.ComputeRequest.DiskSize}
 	if args.Spot != nil {
 		r.spot = args.Spot.Spot
 	}
@@ -218,6 +220,10 @@ func (r *openshiftSNCRequest) deploy(ctx *pulumi.Context) error {
 	ctx.Export(fmt.Sprintf("%s-%s", *r.prefix, apiSNC.OutputDeveloperPass),
 		devPass)
 	// Create instance
+	effectiveDiskSize := diskSize
+	if r.diskSize != nil {
+		effectiveDiskSize = *r.diskSize
+	}
 	cr := compute.ComputeRequest{
 		MCtx:             r.mCtx,
 		Prefix:           *r.prefix,
@@ -228,7 +234,7 @@ func (r *openshiftSNCRequest) deploy(ctx *pulumi.Context) error {
 		KeyResources:     keyResources,
 		SecurityGroups:   securityGroups,
 		InstaceTypes:     r.allocationData.InstanceTypes,
-		DiskSize:         &diskSize,
+		DiskSize:         &effectiveDiskSize,
 		LB:               nw.LoadBalancer,
 		Eip:              nw.Eip,
 		LBTargetGroups:   []int{securityGroup.SSH_PORT, apiSNC.PortHTTPS, apiSNC.PortAPI},

--- a/pkg/provider/aws/action/windows/windows.go
+++ b/pkg/provider/aws/action/windows/windows.go
@@ -69,6 +69,7 @@ type windowsServerRequest struct {
 	serviceEndpoints []string
 	allocationData *allocation.AllocationResult
 	airgap         *bool
+	diskSize       *int
 	// internal management
 	// For airgap scenario there is an orchestation of
 	// a phase with connectivity on the machine (allowing bootstraping)
@@ -105,16 +106,20 @@ func Create(mCtxArgs *mc.ContextArgs, args *WindowsServerArgs) (err error) {
 	// Compose request
 	prefix := util.If(len(args.Prefix) > 0, args.Prefix, "main")
 	r := windowsServerRequest{
-		mCtx:        mCtx,
-		prefix:      &prefix,
-		amiName:     &args.AMIName,
-		amiUser:     &args.AMIUser,
-		amiOwner:    &args.AMIOwner,
-		amiKeepCopy: &args.AMIKeepCopy,
-		amiLang:     &args.AMILang,
-		timeout:     &args.Timeout,
-		serviceEndpoints:   args.ServiceEndpoints,
-		airgap:      &args.Airgap}
+		mCtx:             mCtx,
+		prefix:           &prefix,
+		amiName:          &args.AMIName,
+		amiUser:          &args.AMIUser,
+		amiOwner:         &args.AMIOwner,
+		amiKeepCopy:      &args.AMIKeepCopy,
+		amiLang:          &args.AMILang,
+		timeout:          &args.Timeout,
+		serviceEndpoints: args.ServiceEndpoints,
+		airgap:           &args.Airgap,
+	}
+	if args.ComputeRequest != nil {
+		r.diskSize = args.ComputeRequest.DiskSize
+	}
 	if args.Spot != nil {
 		r.spot = args.Spot.Spot
 	}
@@ -288,6 +293,10 @@ func (r *windowsServerRequest) deploy(ctx *pulumi.Context) error {
 		return err
 	}
 
+	effectiveDiskSize := diskSize
+	if r.diskSize != nil {
+		effectiveDiskSize = *r.diskSize
+	}
 	cr := compute.ComputeRequest{
 		MCtx:             r.mCtx,
 		Prefix:           *r.prefix,
@@ -299,7 +308,7 @@ func (r *windowsServerRequest) deploy(ctx *pulumi.Context) error {
 		KeyResources:     keyResources,
 		SecurityGroups:   securityGroups,
 		InstaceTypes:     requiredInstanceTypes,
-		DiskSize:         &diskSize,
+		DiskSize:         &effectiveDiskSize,
 		Airgap:           *r.airgap,
 		LB:               nw.LoadBalancer,
 		Eip:              nw.Eip,

--- a/pkg/provider/azure/action/kind/kind.go
+++ b/pkg/provider/azure/action/kind/kind.go
@@ -32,6 +32,7 @@ type kindRequest struct {
 	spot              bool
 	allocationData    *allocation.AllocationResult
 	extraPortMappings []utilKind.PortMapping
+	diskSize          *int
 }
 
 func (r *kindRequest) validate() error {
@@ -56,6 +57,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *utilKind.KindArgs) (*utilKind.KindRe
 		version:           &args.Version,
 		arch:              &args.Arch,
 		extraPortMappings: args.ExtraPortMappings,
+		diskSize:          args.ComputeRequest.DiskSize,
 	}
 	if args.Spot != nil {
 		r.spot = args.Spot.Spot
@@ -177,6 +179,7 @@ func (r *kindRequest) deployer(ctx *pulumi.Context) error {
 			UserDataAsBase64: udB64,
 			Location:         *r.allocationData.Location,
 			AdminUsername:    amiUserDefault,
+			DiskSize:         r.diskSize,
 		})
 	if err != nil {
 		return err

--- a/pkg/provider/azure/action/linux/linux.go
+++ b/pkg/provider/azure/action/linux/linux.go
@@ -64,6 +64,7 @@ type linuxRequest struct {
 	username              *string
 	cloudConfigAsUserData userDataApi.CloudConfig
 	readinessCommand      *string
+	diskSize              *int
 }
 
 func (r *linuxRequest) validate() error {
@@ -91,6 +92,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *LinuxArgs) (err error) {
 		username:              &args.Username,
 		cloudConfigAsUserData: args.CloudConfigAsUserData,
 		readinessCommand:      &args.ReadinessCommand,
+		diskSize:              args.ComputeRequest.DiskSize,
 	}
 	ir := args.ImageRef
 	if ir == nil {
@@ -191,6 +193,7 @@ func (r *linuxRequest) deployer(ctx *pulumi.Context) error {
 		PrivateKey:    privateKey,
 		SpotPrice:     r.allocationData.Price,
 		Location:      *r.allocationData.Location,
+		DiskSize:      r.diskSize,
 	}
 	if r.cloudConfigAsUserData != nil {
 		userDataB64, err := r.cloudConfigAsUserData.CloudConfig()

--- a/pkg/provider/azure/action/windows/rhqp-ci-setup.ps1
+++ b/pkg/provider/azure/action/windows/rhqp-ci-setup.ps1
@@ -46,6 +46,25 @@ $parameters = @{
 }
 Invoke-Command -asjob @parameters
 
+# Extend the Windows partition to max size (with error handling)
+try {
+    $drive_letter = "C"
+    $partition = Get-Partition -DriveLetter $drive_letter
+    $size = Get-PartitionSupportedSize -DriveLetter $drive_letter
+
+    # Only resize if there's actually space to expand
+    if ($size.SizeMax -gt $partition.Size) {
+        Write-Host "Expanding partition from $($partition.Size) to $($size.SizeMax)"
+        Resize-Partition -DriveLetter $drive_letter -Size $size.SizeMax
+        Write-Host "Partition expanded successfully"
+    } else {
+        Write-Host "Partition is already at maximum size"
+    }
+} catch {
+    Write-Warning "Failed to expand partition: $_"
+    # Don't fail the entire script if resize fails
+}
+
 # Set autologon to user to allow start sshd for the user
 # Check requirements for domain user
 # https://docs.microsoft.com/en-us/troubleshoot/windows-server/user-profiles-and-logon/turn-on-automatic-logon

--- a/pkg/provider/azure/action/windows/windows.go
+++ b/pkg/provider/azure/action/windows/windows.go
@@ -62,6 +62,7 @@ type windowsRequest struct {
 	username       *string
 	adminUsername  *string
 	profiles       []string
+	diskSize       *int
 }
 
 func (r *windowsRequest) validate() error {
@@ -94,6 +95,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *WindowsArgs) (err error) {
 		username:      &args.Username,
 		adminUsername: &args.AdminUsername,
 		profiles:      args.Profiles,
+		diskSize:      args.ComputeRequest.DiskSize,
 	}
 	r.allocationData, err = allocation.Allocation(mCtx,
 		&allocation.AllocationArgs{
@@ -195,6 +197,7 @@ func (r *windowsRequest) deployer(ctx *pulumi.Context) error {
 			AdminPasswd:   adminPasswd,
 			SpotPrice:     r.allocationData.Price,
 			Location:      *r.allocationData.Location,
+			DiskSize:      r.diskSize,
 		})
 	if err != nil {
 		return err

--- a/pkg/provider/azure/modules/virtual-machine/virtual-machine.go
+++ b/pkg/provider/azure/modules/virtual-machine/virtual-machine.go
@@ -40,6 +40,7 @@ type VirtualMachineArgs struct {
 	// Only required if we need to set userdata
 	UserDataAsBase64 pulumi.StringPtrInput
 	Location         string
+	DiskSize         *int
 }
 
 type VirtualMachine = *compute.VirtualMachine
@@ -50,6 +51,10 @@ func Create(ctx *pulumi.Context, mCtx *mc.Context, args *VirtualMachineArgs) (Vi
 	ira, err := convertImageRef(mCtx, *args.Image, args.Location)
 	if err != nil {
 		return nil, err
+	}
+	effectiveDiskSize := diskSize
+	if args.DiskSize != nil {
+		effectiveDiskSize = *args.DiskSize
 	}
 	vmArgs := &compute.VirtualMachineArgs{
 		VmName:            pulumi.String(mCtx.RunID()),
@@ -70,7 +75,7 @@ func Create(ctx *pulumi.Context, mCtx *mc.Context, args *VirtualMachineArgs) (Vi
 			ImageReference: ira,
 			OsDisk: compute.OSDiskArgs{
 				Name:         pulumi.String(mCtx.RunID()),
-				DiskSizeGB:   pulumi.Int(diskSize),
+				DiskSizeGB:   pulumi.Int(effectiveDiskSize),
 				CreateOption: pulumi.String("FromImage"),
 				Caching:      compute.CachingTypesReadWrite,
 				ManagedDisk: compute.ManagedDiskParametersArgs{

--- a/tkn/infra-aws-fedora.yaml
+++ b/tkn/infra-aws-fedora.yaml
@@ -103,6 +103,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
@@ -256,6 +259,7 @@ spec:
           if [[ "$(params.nested-virt)" == "true" ]]; then
             cmd+="--nested-virt "
           fi
+          cmd+="--disk-size '$(params.disk-size)' "
           cmd+="--arch '$(params.arch)' "
           cmd+="--version '$(params.version)' "
           if [[ -f /opt/rh-account-secret/user ]]; then

--- a/tkn/infra-aws-kind.yaml
+++ b/tkn/infra-aws-kind.yaml
@@ -91,6 +91,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: 'false'
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: 'true'
@@ -222,6 +225,7 @@ spec:
           if [[ $(params.nested-virt) == "true" ]]; then
             cmd+="--nested-virt "
           fi
+          cmd+="--disk-size $(params.disk-size) "
           if [[ $(params.version) != "" ]]; then
             cmd+="--version $(params.version) "
           fi

--- a/tkn/infra-aws-ocp-snc.yaml
+++ b/tkn/infra-aws-ocp-snc.yaml
@@ -106,6 +106,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: 'false'
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: 'true'
@@ -245,6 +248,7 @@ spec:
           if [[ $(params.nested-virt) == "true" ]]; then
             cmd+="--nested-virt "
           fi
+          cmd+="--disk-size $(params.disk-size) "
           if [[ -f /opt/ocp-snc-secret/pull-secret ]]; then
             cmd+="--pull-secret-file /opt/ocp-snc-secret/pull-secret "
           fi

--- a/tkn/infra-aws-rhel-ai.yaml
+++ b/tkn/infra-aws-rhel-ai.yaml
@@ -118,6 +118,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
@@ -263,6 +266,7 @@ spec:
           if [[ "$(params.nested-virt)" == "true" ]]; then
             cmd+="--nested-virt "
           fi
+          cmd+="--disk-size '$(params.disk-size)' "
           if [[ "$(params.custom-image)" != "" ]]; then
             cmd+="--custom-image '$(params.custom-image)' "
           else

--- a/tkn/infra-aws-rhel.yaml
+++ b/tkn/infra-aws-rhel.yaml
@@ -118,6 +118,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
@@ -279,6 +282,7 @@ spec:
             cmd+="--nested-virt "
           fi
           cmd+="--arch '$(params.arch)' "
+          cmd+="--disk-size '$(params.disk-size)' "
           cmd+="--version '$(params.version)' "
           if [[ -f /opt/rh-account-secret/user ]]; then
             cmd+="--rh-subscription-username '$(cat /opt/rh-account-secret/user)' "

--- a/tkn/infra-aws-windows-server.yaml
+++ b/tkn/infra-aws-windows-server.yaml
@@ -97,11 +97,16 @@ spec:
       description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
       default: '20'
     - name: spot-eviction-tolerance
-      description: | 
-        if spot is enable we can define the minimum tolerance level of eviction. 
+      description: |
+        if spot is enable we can define the minimum tolerance level of eviction.
         Allowed value are: lowest, low, medium, high or highest
       default: 'lowest'
-      
+
+    # Compute params
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
+
     - name: airgap
       description: |
           Set the machine on an airgap scenario. 
@@ -228,8 +233,9 @@ spec:
           cmd+="--ami-username $(params.ami-username) "
           cmd+="--ami-owner $(params.ami-owner) "
           cmd+="--ami-lang $(params.ami-lang) "
-          if [[ $(params.spot) == "true" ]]; then 
-            cmd+="--spot --spot-increase-rate $(params.spot-increase-rate) --spot-eviction-tolerance $(params.spot-eviction-tolerance) " 
+          cmd+="--disk-size $(params.disk-size) "
+          if [[ $(params.spot) == "true" ]]; then
+            cmd+="--spot --spot-increase-rate $(params.spot-increase-rate) --spot-eviction-tolerance $(params.spot-eviction-tolerance) "
           fi
           if [[ $(params.airgap) == "true" ]]; then cmd+="--airgap "; fi
           if [[ $(params.service-endpoints) != "" ]]; then cmd+="--service-endpoints $(params.service-endpoints) "; fi

--- a/tkn/infra-azure-fedora.yaml
+++ b/tkn/infra-azure-fedora.yaml
@@ -105,6 +105,9 @@ spec:
     - name: nested-virt
       description: Nested virtualization support on the machine
       default: "false"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: spot
       description: in case spot is set to true it 'ill check for best spot price and create the VM on the target region
       default: "true"
@@ -233,6 +236,7 @@ spec:
           fi
           cmd+="--arch '$(params.arch)' "
           cmd+="--version '$(params.version)' "
+          cmd+="--disk-size '$(params.disk-size)' "
           if [[ "$(params.spot)" == "true" ]]; then
             cmd+="--spot "
             cmd+="--spot-eviction-tolerance '$(params.spot-eviction-tolerance)' "

--- a/tkn/infra-azure-rhel-ai.yaml
+++ b/tkn/infra-azure-rhel-ai.yaml
@@ -82,6 +82,9 @@ spec:
     - name: accelerator
       description: accelerator for RHEL AI OS rocm or cuda (default rocm)
       default: "rocm"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: compute-sizes
       description: Comma seperated list of sizes for the machines to be requested. If set this takes precedence over compute by args
       default: "Standard_ND96is_MI300X_v5,Standard_ND96isr_MI300X_v5"
@@ -230,7 +233,7 @@ spec:
           else
             cmd+="--version '$(params.version)' "
           fi
-
+          cmd+="--disk-size '$(params.disk-size)' "
           if [[ "$(params.spot)" == "true" ]]; then
             cmd+="--spot "
             cmd+="--spot-increase-rate '$(params.spot-increase-rate)' "

--- a/tkn/infra-azure-rhel.yaml
+++ b/tkn/infra-azure-rhel.yaml
@@ -105,6 +105,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: spot
       description: in case spot is set to true it will check for best spot price and create the VM on the target region
       default: "true"
@@ -237,6 +240,7 @@ spec:
           fi
           cmd+="--arch '$(params.arch)' "
           cmd+="--version '$(params.version)' "
+          cmd+="--disk-size '$(params.disk-size)' "
           if [[ "$(params.spot)" == "true" ]]; then
             cmd+="--spot "
             cmd+="--spot-eviction-tolerance '$(params.spot-eviction-tolerance)' "

--- a/tkn/infra-azure-windows-desktop.yaml
+++ b/tkn/infra-azure-windows-desktop.yaml
@@ -90,6 +90,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: 'false'
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
     - name: compute-sizes
       description: Comma separated list of sizes for the machine
       default: "''"
@@ -219,6 +222,7 @@ spec:
           cmd+="--memory $(params.memory) "
           if [[ $(params.nested-virt) == "true" ]]; then cmd+="--nested-virt "; fi
           if [[ -n $(params.compute-sizes) ]]; then cmd+="--compute-sizes $(params.compute-sizes) "; fi
+          cmd+="--disk-size $(params.disk-size) "
           if [[ "$(params.spot)" == "true" ]]; then
             cmd+="--spot "
             cmd+="--spot-increase-rate '$(params.spot-increase-rate)' "

--- a/tkn/template/infra-aws-fedora.yaml
+++ b/tkn/template/infra-aws-fedora.yaml
@@ -103,6 +103,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
@@ -256,6 +259,7 @@ spec:
           if [[ "$(params.nested-virt)" == "true" ]]; then
             cmd+="--nested-virt "
           fi
+          cmd+="--disk-size '$(params.disk-size)' "
           cmd+="--arch '$(params.arch)' "
           cmd+="--version '$(params.version)' "
           if [[ -f /opt/rh-account-secret/user ]]; then

--- a/tkn/template/infra-aws-kind.yaml
+++ b/tkn/template/infra-aws-kind.yaml
@@ -91,6 +91,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: 'false'
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: 'true'
@@ -222,6 +225,7 @@ spec:
           if [[ $(params.nested-virt) == "true" ]]; then
             cmd+="--nested-virt "
           fi
+          cmd+="--disk-size $(params.disk-size) "
           if [[ $(params.version) != "" ]]; then
             cmd+="--version $(params.version) "
           fi

--- a/tkn/template/infra-aws-ocp-snc.yaml
+++ b/tkn/template/infra-aws-ocp-snc.yaml
@@ -106,6 +106,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: 'false'
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: 'true'
@@ -245,6 +248,7 @@ spec:
           if [[ $(params.nested-virt) == "true" ]]; then
             cmd+="--nested-virt "
           fi
+          cmd+="--disk-size $(params.disk-size) "
           if [[ -f /opt/ocp-snc-secret/pull-secret ]]; then
             cmd+="--pull-secret-file /opt/ocp-snc-secret/pull-secret "
           fi

--- a/tkn/template/infra-aws-rhel-ai.yaml
+++ b/tkn/template/infra-aws-rhel-ai.yaml
@@ -118,6 +118,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
@@ -263,6 +266,7 @@ spec:
           if [[ "$(params.nested-virt)" == "true" ]]; then
             cmd+="--nested-virt "
           fi
+          cmd+="--disk-size '$(params.disk-size)' "
           if [[ "$(params.custom-image)" != "" ]]; then
             cmd+="--custom-image '$(params.custom-image)' "
           else

--- a/tkn/template/infra-aws-rhel.yaml
+++ b/tkn/template/infra-aws-rhel.yaml
@@ -118,6 +118,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
@@ -279,6 +282,7 @@ spec:
             cmd+="--nested-virt "
           fi
           cmd+="--arch '$(params.arch)' "
+          cmd+="--disk-size '$(params.disk-size)' "
           cmd+="--version '$(params.version)' "
           if [[ -f /opt/rh-account-secret/user ]]; then
             cmd+="--rh-subscription-username '$(cat /opt/rh-account-secret/user)' "

--- a/tkn/template/infra-aws-windows-server.yaml
+++ b/tkn/template/infra-aws-windows-server.yaml
@@ -97,11 +97,16 @@ spec:
       description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
       default: '20'
     - name: spot-eviction-tolerance
-      description: | 
-        if spot is enable we can define the minimum tolerance level of eviction. 
+      description: |
+        if spot is enable we can define the minimum tolerance level of eviction.
         Allowed value are: lowest, low, medium, high or highest
       default: 'lowest'
-      
+
+    # Compute params
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
+
     - name: airgap
       description: |
           Set the machine on an airgap scenario. 
@@ -228,8 +233,9 @@ spec:
           cmd+="--ami-username $(params.ami-username) "
           cmd+="--ami-owner $(params.ami-owner) "
           cmd+="--ami-lang $(params.ami-lang) "
-          if [[ $(params.spot) == "true" ]]; then 
-            cmd+="--spot --spot-increase-rate $(params.spot-increase-rate) --spot-eviction-tolerance $(params.spot-eviction-tolerance) " 
+          cmd+="--disk-size $(params.disk-size) "
+          if [[ $(params.spot) == "true" ]]; then
+            cmd+="--spot --spot-increase-rate $(params.spot-increase-rate) --spot-eviction-tolerance $(params.spot-eviction-tolerance) "
           fi
           if [[ $(params.airgap) == "true" ]]; then cmd+="--airgap "; fi
           if [[ $(params.service-endpoints) != "" ]]; then cmd+="--service-endpoints $(params.service-endpoints) "; fi

--- a/tkn/template/infra-azure-fedora.yaml
+++ b/tkn/template/infra-azure-fedora.yaml
@@ -105,6 +105,9 @@ spec:
     - name: nested-virt
       description: Nested virtualization support on the machine
       default: "false"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: spot
       description: in case spot is set to true it 'ill check for best spot price and create the VM on the target region
       default: "true"
@@ -233,6 +236,7 @@ spec:
           fi
           cmd+="--arch '$(params.arch)' "
           cmd+="--version '$(params.version)' "
+          cmd+="--disk-size '$(params.disk-size)' "
           if [[ "$(params.spot)" == "true" ]]; then
             cmd+="--spot "
             cmd+="--spot-eviction-tolerance '$(params.spot-eviction-tolerance)' "

--- a/tkn/template/infra-azure-rhel-ai.yaml
+++ b/tkn/template/infra-azure-rhel-ai.yaml
@@ -82,6 +82,9 @@ spec:
     - name: accelerator
       description: accelerator for RHEL AI OS rocm or cuda (default rocm)
       default: "rocm"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: compute-sizes
       description: Comma seperated list of sizes for the machines to be requested. If set this takes precedence over compute by args
       default: "Standard_ND96is_MI300X_v5,Standard_ND96isr_MI300X_v5"
@@ -230,7 +233,7 @@ spec:
           else
             cmd+="--version '$(params.version)' "
           fi
-
+          cmd+="--disk-size '$(params.disk-size)' "
           if [[ "$(params.spot)" == "true" ]]; then
             cmd+="--spot "
             cmd+="--spot-increase-rate '$(params.spot-increase-rate)' "

--- a/tkn/template/infra-azure-rhel.yaml
+++ b/tkn/template/infra-azure-rhel.yaml
@@ -105,6 +105,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: spot
       description: in case spot is set to true it will check for best spot price and create the VM on the target region
       default: "true"
@@ -237,6 +240,7 @@ spec:
           fi
           cmd+="--arch '$(params.arch)' "
           cmd+="--version '$(params.version)' "
+          cmd+="--disk-size '$(params.disk-size)' "
           if [[ "$(params.spot)" == "true" ]]; then
             cmd+="--spot "
             cmd+="--spot-eviction-tolerance '$(params.spot-eviction-tolerance)' "

--- a/tkn/template/infra-azure-windows-desktop.yaml
+++ b/tkn/template/infra-azure-windows-desktop.yaml
@@ -90,6 +90,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: 'false'
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
     - name: compute-sizes
       description: Comma separated list of sizes for the machine
       default: "''"
@@ -219,6 +222,7 @@ spec:
           cmd+="--memory $(params.memory) "
           if [[ $(params.nested-virt) == "true" ]]; then cmd+="--nested-virt "; fi
           if [[ -n $(params.compute-sizes) ]]; then cmd+="--compute-sizes $(params.compute-sizes) "; fi
+          cmd+="--disk-size $(params.disk-size) "
           if [[ "$(params.spot)" == "true" ]]; then
             cmd+="--spot "
             cmd+="--spot-increase-rate '$(params.spot-increase-rate)' "


### PR DESCRIPTION
Add --disk-size flag to allow users to specify custom disk size in GB
for cloud instances. Default is 200GB. The parameter is optional and
providers use their defaults when not specified.

- Add disk-size parameter to compute request flags
- Store DiskSize as optional pointer in ComputeRequestArgs
- Set default disk size to 200GB