### PR TITLE
fix(kind): Do not export spot price when non-spot request for Kind

### DIFF
--- a/pkg/provider/aws/action/kind/kind.go
+++ b/pkg/provider/aws/action/kind/kind.go
@@ -119,7 +119,7 @@ func (r *kindRequest) createHost() (*utilKind.KindResults, error) {
 		return nil, fmt.Errorf("stack creation failed: %w", err)
 	}
 
-	metadataResults, err := utilKind.Results(r.mCtx, sr, r.prefix)
+	metadataResults, err := utilKind.Results(r.mCtx, sr, r.prefix, r.spot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to manage results: %w", err)
 	}
@@ -131,8 +131,10 @@ func (r *kindRequest) deploy(ctx *pulumi.Context) error {
 	if err := r.validate(); err != nil {
 		return err
 	}
-	ctx.Export(fmt.Sprintf("%s-%s", *r.prefix, utilKind.OKSpotPrice),
-		pulumi.Float64(*r.allocationData.SpotPrice))
+	if r.spot {
+		ctx.Export(fmt.Sprintf("%s-%s", *r.prefix, utilKind.OKSpotPrice),
+			pulumi.Float64(*r.allocationData.SpotPrice))
+	}
 	// Get AMI
 	ami, err := amiSVC.GetAMIByName(ctx,
 		amiName(r.arch),

--- a/pkg/provider/azure/action/kind/kind.go
+++ b/pkg/provider/azure/action/kind/kind.go
@@ -86,7 +86,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *utilKind.KindArgs) (*utilKind.KindRe
 		return nil, fmt.Errorf("stack creation failed: %w", err)
 	}
 
-	metadataResults, err := utilKind.Results(r.mCtx, sr, r.prefix)
+	metadataResults, err := utilKind.Results(r.mCtx, sr, r.prefix, r.spot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to manage results: %w", err)
 	}
@@ -109,8 +109,10 @@ func (r *kindRequest) deployer(ctx *pulumi.Context) error {
 	if err := r.validate(); err != nil {
 		return err
 	}
-	ctx.Export(fmt.Sprintf("%s-%s", *r.prefix, utilKind.OKSpotPrice),
-		pulumi.Float64(*r.allocationData.Price))
+	if r.spot {
+		ctx.Export(fmt.Sprintf("%s-%s", *r.prefix, utilKind.OKSpotPrice),
+			pulumi.Float64(*r.allocationData.Price))
+	}
 	// Get location for creating the Resource Group
 	rgLocation := azure.GetSuitableLocationForResourceGroup(*r.allocationData.Location)
 	rg, err := resources.NewResourceGroup(ctx,

--- a/pkg/target/service/kind/util.go
+++ b/pkg/target/service/kind/util.go
@@ -17,7 +17,7 @@ const (
 	OKSpotPrice  = "kndSpotPrice"
 )
 
-func Results(mCtx *mc.Context, stackResult auto.UpResult, prefix *string) (*KindResults, error) {
+func Results(mCtx *mc.Context, stackResult auto.UpResult, prefix *string, spot bool) (*KindResults, error) {
 	username, err := get[string](OKUsername, stackResult, prefix)
 	if err != nil {
 		return nil, err
@@ -34,9 +34,12 @@ func Results(mCtx *mc.Context, stackResult auto.UpResult, prefix *string) (*Kind
 	if err != nil {
 		return nil, err
 	}
-	spotPrice, err := get[float64](OKSpotPrice, stackResult, prefix)
-	if err != nil {
-		return nil, err
+	var spotPrice *float64
+	if spot {
+		spotPrice, err = get[float64](OKSpotPrice, stackResult, prefix)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if mCtx.GetResultsOutputPath() != "" {
 		if err := output.Write(stackResult, mCtx.GetResultsOutputPath(), map[string]string{


### PR DESCRIPTION
This commit ensure spot price is not exported when non-spot is requested, otherwise it will try to access a value of a nil pointer

Fixes #784 