### PR TITLE
fix(release): add --repo flag to gh release create

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -152,4 +152,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
-        run: gh release create "$TAG" mapt-linux-* mapt-checksums.txt --generate-notes
+        run: gh release create "$TAG" mapt-linux-* mapt-checksums.txt --generate-notes --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
The `release` job was failing with `fatal: not a git repository` because `gh release create` needs git context to determine the target repo. The job only downloads binary artifacts — it never checks out the code. Adding `--repo "$GITHUB_REPOSITORY"` provides that context via the GitHub API without requiring a full checkout.

Fixes: https://github.com/redhat-developer/mapt/actions/runs/25001661831/job/73215210704

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>