### PR TITLE
fix(release): use --notes-start-tag for correct changelogs

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -148,8 +148,18 @@ jobs:
           merge-multiple: true
       - name: Create checksums
         run: sha256sum mapt-linux-* > mapt-checksums.txt
+      - name: Get previous release tag
+        id: prev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 --json tagName --jq '.[0].tagName')" >> "$GITHUB_OUTPUT"
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
-        run: gh release create "$TAG" mapt-linux-* mapt-checksums.txt --generate-notes --repo "$GITHUB_REPOSITORY"
+        run: |
+          ARGS="--generate-notes"
+          if [ -n "${{ steps.prev.outputs.tag }}" ]; then
+            ARGS="$ARGS --notes-start-tag ${{ steps.prev.outputs.tag }}"
+          fi
+          gh release create "$TAG" mapt-linux-* mapt-checksums.txt $ARGS --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
`--generate-notes` falls back to v0.6.0 because each release has a `chore(cut)` commit that never gets merged back to main, so no recent release tag is an ancestor of the current tag. This fetches the previous release tag explicitly and passes it via `--notes-start-tag`.

Fixes: [AIPCC-16038](https://redhat.atlassian.net/browse/AIPCC-16038)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>