### PR TITLE
fix: remove trailing newline from connection detail output files

### DIFF
--- a/tkn/infra-aws-eks.yaml
+++ b/tkn/infra-aws-eks.yaml
@@ -289,7 +289,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/infra-aws-fedora.yaml
+++ b/tkn/infra-aws-fedora.yaml
@@ -342,15 +342,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         fi
 

--- a/tkn/infra-aws-kind.yaml
+++ b/tkn/infra-aws-kind.yaml
@@ -302,7 +302,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/infra-aws-mac.yaml
+++ b/tkn/infra-aws-mac.yaml
@@ -294,15 +294,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         fi
 

--- a/tkn/infra-aws-ocp-snc.yaml
+++ b/tkn/infra-aws-ocp-snc.yaml
@@ -334,7 +334,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/infra-aws-rhel-ai.yaml
+++ b/tkn/infra-aws-rhel-ai.yaml
@@ -350,9 +350,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/infra-aws-rhel.yaml
+++ b/tkn/infra-aws-rhel.yaml
@@ -368,15 +368,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         fi
 

--- a/tkn/infra-aws-windows-server.yaml
+++ b/tkn/infra-aws-windows-server.yaml
@@ -301,15 +301,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         fi
 

--- a/tkn/infra-azure-aks.yaml
+++ b/tkn/infra-azure-aks.yaml
@@ -258,7 +258,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/infra-azure-fedora.yaml
+++ b/tkn/infra-azure-fedora.yaml
@@ -297,9 +297,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/infra-azure-rhel-ai.yaml
+++ b/tkn/infra-azure-rhel-ai.yaml
@@ -302,9 +302,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/infra-azure-rhel.yaml
+++ b/tkn/infra-azure-rhel.yaml
@@ -301,9 +301,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/infra-azure-windows-desktop.yaml
+++ b/tkn/infra-azure-windows-desktop.yaml
@@ -281,12 +281,12 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
-          userpassword: $(cat /opt/host-info/userpassword | base64 -w0)
-          adminusername: $(cat /opt/host-info/adminusername | base64 -w0)
-          adminuserpassword: $(cat /opt/host-info/adminuserpassword | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          userpassword: $(cat /opt/host-info/userpassword | tr -d '\n\r' | base64 -w0)
+          adminusername: $(cat /opt/host-info/adminusername | tr -d '\n\r' | base64 -w0)
+          adminuserpassword: $(cat /opt/host-info/adminuserpassword | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/template/infra-aws-eks.yaml
+++ b/tkn/template/infra-aws-eks.yaml
@@ -289,7 +289,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/template/infra-aws-fedora.yaml
+++ b/tkn/template/infra-aws-fedora.yaml
@@ -342,15 +342,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         fi
 

--- a/tkn/template/infra-aws-kind.yaml
+++ b/tkn/template/infra-aws-kind.yaml
@@ -302,7 +302,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/template/infra-aws-mac.yaml
+++ b/tkn/template/infra-aws-mac.yaml
@@ -294,15 +294,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         fi
 

--- a/tkn/template/infra-aws-ocp-snc.yaml
+++ b/tkn/template/infra-aws-ocp-snc.yaml
@@ -334,7 +334,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/template/infra-aws-rhel-ai.yaml
+++ b/tkn/template/infra-aws-rhel-ai.yaml
@@ -350,9 +350,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/template/infra-aws-rhel.yaml
+++ b/tkn/template/infra-aws-rhel.yaml
@@ -368,15 +368,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         fi
 

--- a/tkn/template/infra-aws-windows-server.yaml
+++ b/tkn/template/infra-aws-windows-server.yaml
@@ -301,15 +301,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
         fi
 

--- a/tkn/template/infra-azure-aks.yaml
+++ b/tkn/template/infra-azure-aks.yaml
@@ -258,7 +258,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/template/infra-azure-fedora.yaml
+++ b/tkn/template/infra-azure-fedora.yaml
@@ -297,9 +297,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/template/infra-azure-rhel-ai.yaml
+++ b/tkn/template/infra-azure-rhel-ai.yaml
@@ -302,9 +302,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/template/infra-azure-rhel.yaml
+++ b/tkn/template/infra-azure-rhel.yaml
@@ -301,9 +301,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/template/infra-azure-windows-desktop.yaml
+++ b/tkn/template/infra-azure-windows-desktop.yaml
@@ -281,12 +281,12 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
-          userpassword: $(cat /opt/host-info/userpassword | base64 -w0)
-          adminusername: $(cat /opt/host-info/adminusername | base64 -w0)
-          adminuserpassword: $(cat /opt/host-info/adminuserpassword | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          userpassword: $(cat /opt/host-info/userpassword | tr -d '\n\r' | base64 -w0)
+          adminusername: $(cat /opt/host-info/adminusername | tr -d '\n\r' | base64 -w0)
+          adminuserpassword: $(cat /opt/host-info/adminuserpassword | tr -d '\n\r' | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then


### PR DESCRIPTION
## Summary

The `writeOutput` function in `pkg/provider/util/output/output.go` appends `"\n"` to every value written to connection detail files (`host`, `username`, etc.). This trailing newline propagates through the Tekton task pipeline and causes SSH connection failures in downstream consumers.

## Root cause

The full chain:

1. **mapt** writes `fedora\n` to `/opt/host-info/username` (the `+"\n"` on [line 25](https://github.com/redhat-developer/mapt/blob/main/pkg/provider/util/output/output.go#L25))
2. The **Tekton `host-info-secret` step** base64-encodes the file contents into a Kubernetes Secret — the newline is faithfully encoded (`ZmVkb3JhCg==` instead of `ZmVkb3Jh`)
3. **Kubernetes** decodes the Secret value back via `secretKeyRef` and sets the env var with the newline preserved: `USERNAME=fedora\n`
4. Downstream tasks build an SSH command: `ssh_cmd="ssh ... ${USERNAME}@${HOST}"`  
   With the newline, this becomes: `ssh ... fedora\n@ec2-host\n`
5. When `${ssh_cmd}` is expanded **unquoted**, bash word-splits on the newline, producing:
   ```
   [ssh] [...] [fedora] [@ec2-host]
   ```
6. SSH interprets `fedora` as the hostname → **`"Could not resolve hostname fedora: Name or service not known"`**

## Reproduction

Verified inside the `quay.io/redhat-developer/mapt:v1.0.0-dev` container:

```
=== WITH newline ===
ssh_cmd with cat -v:
ssh -o StrictHostKeyChecking=no fedora
@ec2-1-2-3-4.compute.amazonaws.com
Word split:
  [ssh]  [-o]  [StrictHostKeyChecking=no]  [fedora]  [@ec2-1-2-3-4.compute.amazonaws.com]

=== WITHOUT newline ===
ssh_cmd with cat -v:
ssh -o StrictHostKeyChecking=no fedora@ec2-1-2-3-4.compute.amazonaws.com
Word split:
  [ssh]  [-o]  [StrictHostKeyChecking=no]  [fedora@ec2-1-2-3-4.compute.amazonaws.com]
```

## Fix

Remove the `+"\n"` from `writeOutput`. The output files are only consumed by the Tekton `host-info-secret` step which pipes them through `base64 -w0` — no consumer depends on a trailing newline.