### PR TITLE
snc: update the AMI regex to remove `-` after arch

### DIFF
--- a/pkg/provider/aws/action/snc/constants.go
+++ b/pkg/provider/aws/action/snc/constants.go
@@ -8,7 +8,7 @@ var (
 	// This is managed by https://github.com/devtools-qe-incubator/cloud-importer
 	amiProduct = "Linux/UNIX"
 	// amiProductDescription = "Red Hat Enterprise Linux"
-	amiRegex       = "openshift-local-%s-%s-*"
+	amiRegex       = "openshift-local-%s-%s*"
 	amiUserDefault = "core"
 	amiOwner       = "391597328979"
 	// amiOriginRegion       = "us-east-1"


### PR DESCRIPTION
in the first region where the AMI is uploaded the AMI name don't contain the region suffix and no separator

in all the other regions where the AMI is copied from the first region it contains the region as suffix and a `-` added before it to the AMI name, the new  regex will handle both the variants