### PR TITLE
Revert "fix: sanitize host and username values before base64 encoding in secrets"

### DIFF
--- a/tkn/infra-aws-eks.yaml
+++ b/tkn/infra-aws-eks.yaml
@@ -289,7 +289,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/infra-aws-fedora.yaml
+++ b/tkn/infra-aws-fedora.yaml
@@ -342,15 +342,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi
 

--- a/tkn/infra-aws-kind.yaml
+++ b/tkn/infra-aws-kind.yaml
@@ -302,7 +302,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/infra-aws-mac.yaml
+++ b/tkn/infra-aws-mac.yaml
@@ -294,15 +294,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi
 

--- a/tkn/infra-aws-ocp-snc.yaml
+++ b/tkn/infra-aws-ocp-snc.yaml
@@ -334,7 +334,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/infra-aws-rhel-ai.yaml
+++ b/tkn/infra-aws-rhel-ai.yaml
@@ -350,9 +350,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/infra-aws-rhel.yaml
+++ b/tkn/infra-aws-rhel.yaml
@@ -368,15 +368,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi
 

--- a/tkn/infra-aws-windows-server.yaml
+++ b/tkn/infra-aws-windows-server.yaml
@@ -301,15 +301,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi
 

--- a/tkn/infra-azure-aks.yaml
+++ b/tkn/infra-azure-aks.yaml
@@ -258,7 +258,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/infra-azure-fedora.yaml
+++ b/tkn/infra-azure-fedora.yaml
@@ -297,9 +297,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/infra-azure-rhel-ai.yaml
+++ b/tkn/infra-azure-rhel-ai.yaml
@@ -302,9 +302,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/infra-azure-rhel.yaml
+++ b/tkn/infra-azure-rhel.yaml
@@ -301,9 +301,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/infra-azure-windows-desktop.yaml
+++ b/tkn/infra-azure-windows-desktop.yaml
@@ -281,12 +281,12 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
-          userpassword: $(cat /opt/host-info/userpassword | tr -d '\n\r' | base64 -w0)
-          adminusername: $(cat /opt/host-info/adminusername | tr -d '\n\r' | base64 -w0)
-          adminuserpassword: $(cat /opt/host-info/adminuserpassword | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          userpassword: $(cat /opt/host-info/userpassword | base64 -w0)
+          adminusername: $(cat /opt/host-info/adminusername | base64 -w0)
+          adminuserpassword: $(cat /opt/host-info/adminuserpassword | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/template/infra-aws-eks.yaml
+++ b/tkn/template/infra-aws-eks.yaml
@@ -289,7 +289,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/template/infra-aws-fedora.yaml
+++ b/tkn/template/infra-aws-fedora.yaml
@@ -342,15 +342,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi
 

--- a/tkn/template/infra-aws-kind.yaml
+++ b/tkn/template/infra-aws-kind.yaml
@@ -302,7 +302,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/template/infra-aws-mac.yaml
+++ b/tkn/template/infra-aws-mac.yaml
@@ -294,15 +294,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi
 

--- a/tkn/template/infra-aws-ocp-snc.yaml
+++ b/tkn/template/infra-aws-ocp-snc.yaml
@@ -334,7 +334,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/template/infra-aws-rhel-ai.yaml
+++ b/tkn/template/infra-aws-rhel-ai.yaml
@@ -350,9 +350,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/template/infra-aws-rhel.yaml
+++ b/tkn/template/infra-aws-rhel.yaml
@@ -368,15 +368,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi
 

--- a/tkn/template/infra-aws-windows-server.yaml
+++ b/tkn/template/infra-aws-windows-server.yaml
@@ -301,15 +301,15 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
-          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | tr -d '\n\r' | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi
 

--- a/tkn/template/infra-azure-aks.yaml
+++ b/tkn/template/infra-azure-aks.yaml
@@ -258,7 +258,7 @@ spec:
         cat <<EOF >> cluster-info.yaml
         type: Opaque
         data:
-          kubeconfig: $(cat /opt/cluster-info/kubeconfig | tr -d '\n\r' | base64 -w0)
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then

--- a/tkn/template/infra-azure-fedora.yaml
+++ b/tkn/template/infra-azure-fedora.yaml
@@ -297,9 +297,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/template/infra-azure-rhel-ai.yaml
+++ b/tkn/template/infra-azure-rhel-ai.yaml
@@ -302,9 +302,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/template/infra-azure-rhel.yaml
+++ b/tkn/template/infra-azure-rhel.yaml
@@ -301,9 +301,9 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 
         if [[ "$(params.debug)" == "true" ]]; then

--- a/tkn/template/infra-azure-windows-desktop.yaml
+++ b/tkn/template/infra-azure-windows-desktop.yaml
@@ -281,12 +281,12 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
-          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
-          id_rsa: $(cat /opt/host-info/id_rsa | tr -d '\n\r' | base64 -w0)
-          userpassword: $(cat /opt/host-info/userpassword | tr -d '\n\r' | base64 -w0)
-          adminusername: $(cat /opt/host-info/adminusername | tr -d '\n\r' | base64 -w0)
-          adminuserpassword: $(cat /opt/host-info/adminuserpassword | tr -d '\n\r' | base64 -w0)
+          host: $(cat /opt/host-info/host | base64 -w0)
+          username: $(cat /opt/host-info/username | base64 -w0)
+          id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
+          userpassword: $(cat /opt/host-info/userpassword | base64 -w0)
+          adminusername: $(cat /opt/host-info/adminusername | base64 -w0)
+          adminuserpassword: $(cat /opt/host-info/adminuserpassword | base64 -w0)
         EOF
 
         if [[ $(params.debug) == "true" ]]; then


### PR DESCRIPTION
## Summary

- Reverts #799 — the `tr -d '\n\r'` was applied to **all** `base64 -w0` lines including `id_rsa`, which strips internal newlines from PEM private keys and breaks SSH authentication (`Load key "id_rsa": error in libcrypto`)
- Will follow up with a corrected fix that only trims single-line values (host, username, passwords) and leaves multi-line values (id_rsa, kubeconfig) untouched