### PR TITLE
fix(profile): use server-side apply for namespace creation

### DIFF
--- a/pkg/target/service/snc/profile/operator.go
+++ b/pkg/target/service/snc/profile/operator.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apiextensions"
-	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -69,13 +68,7 @@ func installOperator(ctx *pulumi.Context, args *DeployArgs, oi operatorInstall) 
 		if nsName == nil {
 			nsName = pulumi.String(oi.namespace)
 		}
-		ns, err := corev1.NewNamespace(ctx, oi.resourcePrefix+"ns",
-			&corev1.NamespaceArgs{
-				Metadata: &metav1.ObjectMetaArgs{
-					Name: nsName,
-				},
-			},
-			args.k8sOpts(pulumi.DependsOn(deps))...)
+		ns, err := args.newNamespace(ctx, oi.resourcePrefix+"ns", nsName, pulumi.DependsOn(deps))
 		if err != nil {
 			return pulumi.StringOutput{}, err
 		}

--- a/pkg/target/service/snc/profile/profile.go
+++ b/pkg/target/service/snc/profile/profile.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -178,6 +180,18 @@ func GPUManufacturer(profiles []string) string {
 		}
 	}
 	return ""
+}
+
+// newNamespace creates (or adopts) a Kubernetes namespace using server-side
+// apply so the call succeeds even if the namespace already exists.
+func (a *DeployArgs) newNamespace(ctx *pulumi.Context, name string, nsName pulumi.StringInput, extra ...pulumi.ResourceOption) (*corev1.NamespacePatch, error) {
+	return corev1.NewNamespacePatch(ctx, name,
+		&corev1.NamespacePatchArgs{
+			Metadata: &metav1.ObjectMetaPatchArgs{
+				Name: nsName,
+			},
+		},
+		a.k8sOpts(extra...)...)
 }
 
 // k8sOpts returns the common Pulumi resource options for K8s resources:

--- a/pkg/target/service/snc/profile/serverless.go
+++ b/pkg/target/service/snc/profile/serverless.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apiextensions"
-	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -96,14 +95,7 @@ func deployKnativeCR(ctx *pulumi.Context, args *DeployArgs, operatorReady pulumi
 		return cr.namespace
 	}).(pulumi.StringOutput)
 
-	// Create target namespace
-	ns, err := corev1.NewNamespace(ctx, rn(cr.suffix+"-ns"),
-		&corev1.NamespaceArgs{
-			Metadata: &metav1.ObjectMetaArgs{
-				Name: nsName,
-			},
-		},
-		args.k8sOpts(pulumi.DependsOn(args.Deps))...)
+	ns, err := args.newNamespace(ctx, rn(cr.suffix+"-ns"), nsName, pulumi.DependsOn(args.Deps))
 	if err != nil {
 		return nil, pulumi.StringOutput{}, err
 	}

--- a/pkg/target/service/snc/profile/servicemesh.go
+++ b/pkg/target/service/snc/profile/servicemesh.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apiextensions"
-	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -35,26 +34,12 @@ func deployServiceMesh(ctx *pulumi.Context, args *DeployArgs) (pulumi.Resource, 
 		return fmt.Sprintf("%s-smesh-%s", args.Prefix, suffix)
 	}
 
-	// Create istio-system namespace
-	nsSystem, err := corev1.NewNamespace(ctx, rn("ns-system"),
-		&corev1.NamespaceArgs{
-			Metadata: &metav1.ObjectMetaArgs{
-				Name: pulumi.String(istioSystemNamespace),
-			},
-		},
-		args.k8sOpts(pulumi.DependsOn(args.Deps))...)
+	nsSystem, err := args.newNamespace(ctx, rn("ns-system"), pulumi.String(istioSystemNamespace), pulumi.DependsOn(args.Deps))
 	if err != nil {
 		return nil, err
 	}
 
-	// Create istio-cni namespace
-	nsCNI, err := corev1.NewNamespace(ctx, rn("ns-cni"),
-		&corev1.NamespaceArgs{
-			Metadata: &metav1.ObjectMetaArgs{
-				Name: pulumi.String(istioCNINamespace),
-			},
-		},
-		args.k8sOpts(pulumi.DependsOn(args.Deps))...)
+	nsCNI, err := args.newNamespace(ctx, rn("ns-cni"), pulumi.String(istioCNINamespace), pulumi.DependsOn(args.Deps))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/target/service/snc/profile/servicemesh_v2.go
+++ b/pkg/target/service/snc/profile/servicemesh_v2.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apiextensions"
-	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,14 +28,7 @@ func deployServiceMeshV2(ctx *pulumi.Context, args *DeployArgs) (pulumi.Resource
 		return fmt.Sprintf("%s-smeshv2-%s", args.Prefix, suffix)
 	}
 
-	// Create istio-system namespace
-	ns, err := corev1.NewNamespace(ctx, rn("ns"),
-		&corev1.NamespaceArgs{
-			Metadata: &metav1.ObjectMetaArgs{
-				Name: pulumi.String(istioSystemNamespace),
-			},
-		},
-		args.k8sOpts(pulumi.DependsOn(args.Deps))...)
+	ns, err := args.newNamespace(ctx, rn("ns"), pulumi.String(istioSystemNamespace), pulumi.DependsOn(args.Deps))
 	if err != nil {
 		return nil, pulumi.StringOutput{}, err
 	}


### PR DESCRIPTION
## Summary
- Operators (e.g. Serverless) may pre-create namespaces during startup, causing Pulumi NewNamespace to fail with "already exists"
- Switch all profile namespace creation to NewNamespacePatch (server-side apply) which succeeds whether the namespace exists or not
- Extract a shared newNamespace helper on DeployArgs to reduce duplication across profile files

## Test plan
- [x] Verified with serverless-serving profile — NamespacePatch created successfully where NewNamespace previously failed
- [ ] Test with servicemesh and ai profiles to confirm no regressions

Fixes #797 