### PR TITLE
fix(snc-profiles): Fix non reachable api while destroying SNC

### DIFF
--- a/pkg/target/service/snc/profile/profile.go
+++ b/pkg/target/service/snc/profile/profile.go
@@ -208,6 +208,7 @@ func (a *DeployArgs) k8sOpts(extra ...pulumi.ResourceOption) []pulumi.ResourceOp
 // NewK8sProvider creates a Pulumi Kubernetes provider from a kubeconfig string output.
 func NewK8sProvider(ctx *pulumi.Context, name string, kubeconfig pulumi.StringOutput) (*kubernetes.Provider, error) {
 	return kubernetes.NewProvider(ctx, name, &kubernetes.ProviderArgs{
-		Kubeconfig: kubeconfig,
+		Kubeconfig:        kubeconfig,
+		DeleteUnreachable: pulumi.Bool(true),
 	})
 }


### PR DESCRIPTION
Previously we set the delete of any resource deployed on top of SNC as deleted with the underlaying infra, but even in that case during destroy pulumi was trying to reach the SNC api to check the state for resources, and when it is unrechable it was failing the whole destroy operation, we are now forcing the DeleteUnrechable to true, so it bypass it even if it can not reach the cluster to check the state. 

Fixes #809