### PR TITLE
feat(aws): tag elastic IPs, load balancer, and VPC endpoints

### DIFF
--- a/pkg/provider/aws/modules/ec2/compute/compute.go
+++ b/pkg/provider/aws/modules/ec2/compute/compute.go
@@ -368,6 +368,7 @@ func (r ComputeRequest) createForwardTargetGRoups(ctx *pulumi.Context, port int)
 			// Set to 0 for instant deregistration on destroy;
 			// these are ephemeral machines with no live connections to drain.
 			DeregistrationDelay: pulumi.Int(0),
+			Tags:                r.MCtx.ResourceTags(),
 		})
 	if err != nil {
 		return nil, err
@@ -384,6 +385,7 @@ func (r ComputeRequest) createForwardTargetGRoups(ctx *pulumi.Context, port int)
 					TargetGroupArn: tg.Arn,
 				},
 			},
+			Tags: r.MCtx.ResourceTags(),
 		}); err != nil {
 		return nil, err
 	}

--- a/pkg/provider/aws/modules/network/airgap/airgap.go
+++ b/pkg/provider/aws/modules/network/airgap/airgap.go
@@ -53,6 +53,7 @@ func (r AirgapNetworkRequest) CreateNetwork(ctx *pulumi.Context, mCtx *mc.Contex
 	}
 	// Create VPC endpoints for the public subnet
 	err = subnet.EndpointsRequest{
+		MCtx:             mCtx,
 		VPC:              result.VPCResources.VPC,
 		Subnets:          []*ec2.Subnet{result.PublicSubnet.Subnet},
 		RouteTables:      []*ec2.RouteTable{result.PublicSubnet.RouteTable},

--- a/pkg/provider/aws/modules/network/network.go
+++ b/pkg/provider/aws/modules/network/network.go
@@ -76,7 +76,9 @@ func Create(ctx *pulumi.Context, mCtx *mc.Context, args *NetworkArgs) (*NetworkR
 	}
 	result.Eip, err = ec2.NewEip(ctx,
 		resourcesUtil.GetResourceName(args.Prefix, args.ID, "lbeip"),
-		&ec2.EipArgs{})
+		&ec2.EipArgs{
+			Tags: mCtx.ResourceTags(),
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -84,6 +86,7 @@ func Create(ctx *pulumi.Context, mCtx *mc.Context, args *NetworkArgs) (*NetworkR
 		lba := &loadBalancerArgs{
 			prefix: &args.Prefix,
 			id:     &args.ID,
+			mCtx:   mCtx,
 			subnet: result.Subnet,
 		}
 		if !args.Airgap {
@@ -139,6 +142,7 @@ func airgapNetworking(ctx *pulumi.Context, mCtx *mc.Context, args *NetworkArgs) 
 
 type loadBalancerArgs struct {
 	prefix, id *string
+	mCtx       *mc.Context
 	subnet     *ec2.Subnet
 	// If eip != nil it means it is not airgap
 	eip *ec2.Eip
@@ -150,6 +154,7 @@ func loadBalancer(ctx *pulumi.Context, args *loadBalancerArgs) (*lb.LoadBalancer
 	lbArgs := &lb.LoadBalancerArgs{
 		LoadBalancerType:         pulumi.String("network"),
 		EnableDeletionProtection: pulumi.Bool(false),
+		Tags:                     args.mCtx.ResourceTags(),
 	}
 	snMapping := &lb.LoadBalancerSubnetMappingArgs{
 		SubnetId: args.subnet.ID()}

--- a/pkg/provider/aws/modules/network/standard/standard.go
+++ b/pkg/provider/aws/modules/network/standard/standard.go
@@ -128,6 +128,7 @@ func (r NetworkRequest) CreateNetwork(ctx *pulumi.Context) (*NetworkResources, e
 			routeTables[i] = snr.RouteTable
 		}
 		err = subnet.EndpointsRequest{
+			MCtx:             r.MCtx,
 			VPC:              vpcResult.VPC,
 			Subnets:          subnets,
 			RouteTables:      routeTables,

--- a/pkg/provider/aws/services/vpc/subnet/endpoints.go
+++ b/pkg/provider/aws/services/vpc/subnet/endpoints.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/ec2"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	mc "github.com/redhat-developer/mapt/pkg/manager/context"
 )
 
 var validEndpoints = map[string]bool{"s3": true, "ecr": true, "ssm": true}
 
 type EndpointsRequest struct {
+	MCtx             *mc.Context
 	VPC              *ec2.Vpc
 	Subnets          []*ec2.Subnet
 	RouteTables      []*ec2.RouteTable
@@ -51,6 +53,7 @@ func (r EndpointsRequest) Create(ctx *pulumi.Context) error {
 						CidrBlocks: pulumi.StringArray{r.VPC.CidrBlock},
 					},
 				},
+				Tags: r.MCtx.ResourceTags(),
 			})
 		if err != nil {
 			return err
@@ -76,6 +79,7 @@ func (r EndpointsRequest) Create(ctx *pulumi.Context) error {
 					ServiceName:     pulumi.Sprintf("com.amazonaws.%s.s3", r.Region),
 					VpcEndpointType: pulumi.String("Gateway"),
 					RouteTableIds:   routeTableIds,
+					Tags:            r.MCtx.ResourceTags(),
 				})
 			if err != nil {
 				return err
@@ -89,6 +93,7 @@ func (r EndpointsRequest) Create(ctx *pulumi.Context) error {
 					VpcEndpointType:  pulumi.String("Interface"),
 					SubnetIds:        subnetIds,
 					SecurityGroupIds: pulumi.StringArray{sg.ID()},
+					Tags:             r.MCtx.ResourceTags(),
 				})
 			if err != nil {
 				return err
@@ -102,6 +107,7 @@ func (r EndpointsRequest) Create(ctx *pulumi.Context) error {
 					VpcEndpointType:  pulumi.String("Interface"),
 					SubnetIds:        subnetIds,
 					SecurityGroupIds: pulumi.StringArray{sg.ID()},
+					Tags:             r.MCtx.ResourceTags(),
 				})
 			if err != nil {
 				return err

--- a/pkg/provider/aws/services/vpc/subnet/public.go
+++ b/pkg/provider/aws/services/vpc/subnet/public.go
@@ -49,6 +49,7 @@ func (r PublicSubnetRequest) Create(ctx *pulumi.Context, mCtx *mc.Context) (*Pub
 			fmt.Sprintf("%s-%s", "eip", r.Name),
 			&ec2.EipArgs{
 				Domain: pulumi.String("vpc"),
+				Tags:   mCtx.ResourceTags(),
 			})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Most of the resources created by mapt are tagged with user-provided list
of tags. Elastic IPs, load balancer, target groups, listeners, VPC
endpoints, and their security group were not.