### PR TITLE
fix(azure): align non-spot location handling with AWS pattern

### DIFF
--- a/pkg/provider/azure/action/rhel-ai/rhelai.go
+++ b/pkg/provider/azure/action/rhel-ai/rhelai.go
@@ -42,8 +42,7 @@ func Create(mCtxArgs *maptContext.ContextArgs, args *apiRHELAI.RHELAIArgs) (err 
 	}
 	azureLinuxRequest :=
 		&azureLinux.LinuxArgs{
-			Prefix: args.Prefix,
-			// Location:         args.Location,
+			Prefix:         args.Prefix,
 			ComputeRequest: args.ComputeRequest,
 			Spot:           args.Spot,
 			ImageRef: &data.ImageReference{

--- a/pkg/provider/azure/azure.go
+++ b/pkg/provider/azure/azure.go
@@ -42,8 +42,7 @@ func (a *Azure) DefaultHostingPlace() (*string, error) {
 	if len(hp) > 0 {
 		return &hp, nil
 	}
-	logging.Infof("missing default value for Azure Location, if needed it should set using ARM_LOCATION_NAME or AZURE_DEFAULTS_LOCATION")
-	return nil, nil
+	return nil, fmt.Errorf("missing default value for Azure Location, set ARM_LOCATION_NAME or AZURE_DEFAULTS_LOCATION environment variable")
 }
 
 // Envs required for auth with go sdk

--- a/pkg/provider/azure/modules/allocation/allocation.go
+++ b/pkg/provider/azure/modules/allocation/allocation.go
@@ -1,6 +1,8 @@
 package allocation
 
 import (
+	"fmt"
+
 	mc "github.com/redhat-developer/mapt/pkg/manager/context"
 	cr "github.com/redhat-developer/mapt/pkg/provider/api/compute-request"
 	spotTypes "github.com/redhat-developer/mapt/pkg/provider/api/spot"
@@ -55,15 +57,26 @@ func Allocation(mCtx *mc.Context, args *AllocationArgs) (*AllocationResult, erro
 		}, nil
 
 	} else {
+		location := args.Location
+		if location == nil || *location == "" {
+			hp := mCtx.TargetHostingPlace()
+			if hp == "" {
+				return nil, fmt.Errorf("location is required for non-spot allocation: set ARM_LOCATION_NAME or AZURE_DEFAULTS_LOCATION environment variable")
+			}
+			location = &hp
+		}
 		// Filter for current location the computesizes
 		supportedComputeSizes, err := data.FilterComputeSizesByLocation(
-			mCtx.Context(), args.Location, computeSizes)
+			mCtx.Context(), location, computeSizes)
 		if err != nil {
 			return nil, err
 		}
+		if len(supportedComputeSizes) == 0 {
+			return nil, fmt.Errorf("no compute sizes available for location %q", *location)
+		}
 		return &AllocationResult{
 			ImageRef:     args.ImageRef,
-			Location:     args.Location,
+			Location:     location,
 			ComputeSizes: supportedComputeSizes,
 		}, nil
 


### PR DESCRIPTION
`mapt azure rhel-ai create` without `--spot` panicked with `runtime error: index out of range [0] with length 0`. Root cause: `Location` was commented out in the rhel-ai action since the initial commit, so `LinuxArgs.Location` was always `""`. Empty location → `FilterComputeSizesByLocation` matches nothing → `ComputeSizes[0]` panics in the Pulumi deployer.

Two gaps fixed to match AWS behavior:

1. `DefaultHostingPlace()` in `azure.go` now returns an error when neither `ARM_LOCATION_NAME` nor `AZURE_DEFAULTS_LOCATION` is set — same as AWS, which fails at `mc.Init()` rather than silently continuing with no location.
2. `allocation.go` non-spot path falls back to `mCtx.TargetHostingPlace()` when `args.Location` is empty, so the env var is actually respected. Also returns a clear error if no compute sizes match the resolved location instead of returning an empty slice that callers would panic on.

Co-Authored-By: Claude <Sonnet 4.6> <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>