### PR TITLE
fix(azure/rhel-ai): harden RHEL AI provisioning on Azure

### DIFF
--- a/pkg/provider/azure/action/rhel-ai/rhelai.go
+++ b/pkg/provider/azure/action/rhel-ai/rhelai.go
@@ -34,16 +34,41 @@ func imageId(accelerator, version string) string {
 	return imageIdFromName(fmt.Sprintf(imageNameRegex, accelerator, version))
 }
 
+// isGPUCapableSize returns true for ND-series and NC-series Azure VM sizes,
+// which are the compute GPU families supported for RHEL AI workloads.
+// NV-series (visualization GPUs) is intentionally excluded.
+func isGPUCapableSize(vmSize string) bool {
+	lower := strings.ToLower(vmSize)
+	return strings.HasPrefix(lower, "standard_nd") || strings.HasPrefix(lower, "standard_nc")
+}
+
 func Create(mCtxArgs *maptContext.ContextArgs, args *apiRHELAI.RHELAIArgs) (err error) {
-	logging.Debug("Creating RHEL Server")
+	if args == nil || args.ComputeRequest == nil {
+		return fmt.Errorf("RHEL AI: args and ComputeRequest must not be nil")
+	}
+	logging.Debug("Creating RHEL AI Server")
 	sharedImageID := imageId(args.Accelerator, args.Version)
 	if args.CustomImage != "" {
 		sharedImageID = imageIdFromName(args.CustomImage)
 	}
+	// Shallow-copy to avoid mutating the caller's ComputeRequestArgs.
+	computeReq := *args.ComputeRequest
+	// Ensure GPU-capable instance selection for auto-selection paths.
+	if computeReq.GPUs == 0 {
+		logging.Debug("RHEL AI: GPUs not set, defaulting to 1 for GPU-capable instance selection")
+		computeReq.GPUs = 1
+	}
+	// All explicitly specified sizes must be GPU-capable; a single non-GPU entry
+	// could get allocated and vllm would fail silently.
+	for _, s := range computeReq.ComputeSizes {
+		if !isGPUCapableSize(s) {
+			return fmt.Errorf("RHEL AI: %q is not GPU-capable (expected ND-series or NC-series for vllm)", s)
+		}
+	}
 	azureLinuxRequest :=
 		&azureLinux.LinuxArgs{
 			Prefix:         args.Prefix,
-			ComputeRequest: args.ComputeRequest,
+			ComputeRequest: &computeReq,
 			Spot:           args.Spot,
 			ImageRef: &data.ImageReference{
 				SharedImageID: sharedImageID,
@@ -55,7 +80,10 @@ func Create(mCtxArgs *maptContext.ContextArgs, args *apiRHELAI.RHELAIArgs) (err 
 			},
 			Username:         username,
 			ReadinessCommand: command.CommandPing}
-	return azureLinux.Create(mCtxArgs, azureLinuxRequest)
+	if err = azureLinux.Create(mCtxArgs, azureLinuxRequest); err != nil && len(computeReq.ComputeSizes) == 0 {
+		return fmt.Errorf("RHEL AI: failed to provision a GPU-capable instance (ND/NC-series required for vllm); verify GPU quota in the target location/subscription: %w", err)
+	}
+	return err
 }
 
 func Destroy(mCtxArgs *maptContext.ContextArgs) error {

--- a/pkg/provider/azure/action/rhel-ai/rhelai.go
+++ b/pkg/provider/azure/action/rhel-ai/rhelai.go
@@ -47,6 +47,11 @@ func Create(mCtxArgs *maptContext.ContextArgs, args *apiRHELAI.RHELAIArgs) (err 
 			Spot:           args.Spot,
 			ImageRef: &data.ImageReference{
 				SharedImageID: sharedImageID,
+				// Belt-and-suspenders: set SCSI explicitly so Azure never infers a
+				// conflicting default. resolveImageRef will also derive this from the
+				// gallery image's Features, but the static value protects against API
+				// failures or future images with multiple supported types.
+				DiskControllerType: "SCSI",
 			},
 			Username:         username,
 			ReadinessCommand: command.CommandPing}

--- a/pkg/provider/azure/action/rhel-ai/rhelai.go
+++ b/pkg/provider/azure/action/rhel-ai/rhelai.go
@@ -1,6 +1,7 @@
 package rhelai
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -53,6 +54,20 @@ func Create(mCtxArgs *maptContext.ContextArgs, args *apiRHELAI.RHELAIArgs) (err 
 	}
 	// Shallow-copy to avoid mutating the caller's ComputeRequestArgs.
 	computeReq := *args.ComputeRequest
+	if len(computeReq.ComputeSizes) > 0 {
+		ctx := mCtxArgs.Context
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		computeReq.ComputeSizes, err = data.FilterNoLocalStorageSizes(
+			ctx, computeReq.ComputeSizes)
+		if err != nil {
+			return err
+		}
+		if len(computeReq.ComputeSizes) == 0 {
+			return fmt.Errorf("no valid compute sizes: all provided sizes have NVMe-only local storage, incompatible with RHEL AI")
+		}
+	}
 	// Ensure GPU-capable instance selection for auto-selection paths.
 	if computeReq.GPUs == 0 {
 		logging.Debug("RHEL AI: GPUs not set, defaulting to 1 for GPU-capable instance selection")

--- a/pkg/provider/azure/action/rhel-ai/rhelai_test.go
+++ b/pkg/provider/azure/action/rhel-ai/rhelai_test.go
@@ -1,0 +1,29 @@
+package rhelai
+
+import "testing"
+
+func TestIsGPUCapableSize(t *testing.T) {
+	cases := []struct {
+		size     string
+		expected bool
+	}{
+		{"Standard_ND96asr_v4", true},
+		{"Standard_ND40rs_v2", true},
+		{"Standard_NC6s_v3", true},
+		{"Standard_NC24rs_v3", true},
+		{"standard_nd96asr_v4", true},
+		{"standard_nc6s_v3", true},
+		{"Standard_D8as_v5", false},
+		{"Standard_E16as_v5", false},
+		{"Standard_F32s_v2", false},
+		{"Standard_NV6", false},
+		{"Standard_NV36ads_A10_v5", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := isGPUCapableSize(tc.size)
+		if got != tc.expected {
+			t.Errorf("isGPUCapableSize(%q) = %v, want %v", tc.size, got, tc.expected)
+		}
+	}
+}

--- a/pkg/provider/azure/data/compute-request.go
+++ b/pkg/provider/azure/data/compute-request.go
@@ -155,6 +155,7 @@ type virtualMachine struct {
 	// Spot capable
 	LowPriorityCapable  bool
 	MaxResourceVolumeMB int32
+	GPUs                int32
 	// IaaS or PaaS
 	VMDeploymentTypes []string
 	// Fast SSD
@@ -265,6 +266,12 @@ func resourceSKUToVirtualMachine(res *armcompute.ResourceSKU) *virtualMachine {
 				return nil
 			}
 			vm.MaxResourceVolumeMB = int32(disk)
+		case "GPUs":
+			gpus, err := strconv.ParseInt(*capability.Value, 10, 32)
+			if err != nil {
+				return nil
+			}
+			vm.GPUs = int32(gpus)
 		case "VMDeploymentTypes":
 			vm.VMDeploymentTypes = strings.Split(*capability.Value, ",")
 		default:
@@ -287,10 +294,22 @@ func filterCPUsAndMemory(args *cr.ComputeRequestArgs) filterFunc {
 			if args.NestedVirt && !vm.nestedVirtSupported() {
 				return
 			}
+			if args.GPUs > 0 && vm.GPUs < args.GPUs {
+				return
+			}
+			// GPU VMs (ND/NC-series) have large temp disks, so skip the
+			// local-storage check that would otherwise reject them.
+			featuresOK := false
+			if args.GPUs > 0 {
+				featuresOK = vm.AcceleratedNetworkingEnabled && vm.PremiumIO &&
+					vm.EncryptionAtHostSupported && vm.hypervGen2Supported()
+			} else {
+				featuresOK = vm.baseFeaturesSupported()
+			}
 			if vm.VCPUs >= args.CPUs &&
 				vm.Memory >= args.MemoryGib &&
 				vm.Arch == args.Arch.String() &&
-				vm.baseFeaturesSupported() {
+				featuresOK {
 				dSeries := regexp.MustCompile(lowerCpuPattern)
 				if !dSeries.Match([]byte(vm.Name)) {
 					vmCh <- vm.Name

--- a/pkg/provider/azure/data/compute-request.go
+++ b/pkg/provider/azure/data/compute-request.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"regexp"
 	"slices"
@@ -33,7 +34,13 @@ func (c *ComputeSelector) Select(ctx context.Context, args *cr.ComputeRequestArg
 	return getAzureVMSKUs(ctx, args)
 }
 
-func FilterComputeSizesByLocation(ctx context.Context, location *string, computeSizes []string) ([]string, error) {
+// FilterComputeSizesByDiskControllerType returns the subset of computeSizes that are
+// available in location AND support requiredType. Sizes without a DiskControllerTypes
+// capability are assumed to support only SCSI (Azure historical default).
+func FilterComputeSizesByDiskControllerType(ctx context.Context, location *string, computeSizes []string, requiredType string) ([]string, error) {
+	if location == nil {
+		return nil, fmt.Errorf("location cannot be nil")
+	}
 	creds, subscriptionID, err := getCredentials()
 	if err != nil {
 		return nil, err
@@ -43,27 +50,66 @@ func FilterComputeSizesByLocation(ctx context.Context, location *string, compute
 		return nil, err
 	}
 	pager := client.NewListPager(nil)
-	supportedSizes := []string{}
+	supported := []string{}
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
 			return nil, err
 		}
 		for _, sku := range page.Value {
-			if sku.ResourceType != nil &&
-				*sku.ResourceType == string(RTVirtualMachines) {
-				if sku.Name != nil && slices.Contains(computeSizes, *sku.Name) {
-					for _, loc := range sku.Locations {
-						if strings.EqualFold(*loc, *location) {
-							supportedSizes = append(supportedSizes, *sku.Name)
-							break
-						}
-					}
+			if sku.ResourceType == nil || *sku.ResourceType != string(RTVirtualMachines) {
+				continue
+			}
+			if sku.Name == nil || !slices.Contains(computeSizes, *sku.Name) {
+				continue
+			}
+			inLocation := false
+			for _, loc := range sku.Locations {
+				if loc != nil && strings.EqualFold(*loc, *location) {
+					inLocation = true
+					break
 				}
+			}
+			if !inLocation {
+				continue
+			}
+			diskTypes := diskControllerTypesFromCapabilities(sku.Capabilities)
+			if diskControllerTypeSupported(diskTypes, requiredType) && !slices.Contains(supported, *sku.Name) {
+				supported = append(supported, *sku.Name)
 			}
 		}
 	}
-	return supportedSizes, nil
+	return supported, nil
+}
+
+// diskControllerTypesFromCapabilities extracts the DiskControllerTypes value from SKU
+// capabilities. Returns nil when the capability is absent.
+func diskControllerTypesFromCapabilities(caps []*armcompute.ResourceSKUCapabilities) []string {
+	for _, c := range caps {
+		if c.Name != nil && *c.Name == "DiskControllerTypes" && c.Value != nil {
+			return splitDiskControllerTypes(*c.Value)
+		}
+	}
+	return nil
+}
+
+// diskControllerTypeSupported reports whether requiredType is satisfied by the supported
+// set. Empty requiredType means no restriction (always passes). A nil/empty supported
+// set means the capability is absent; Azure sizes that predate NVMe default to SCSI, so
+// absence is treated as SCSI-only.
+func diskControllerTypeSupported(supported []string, requiredType string) bool {
+	if requiredType == "" {
+		return true
+	}
+	if len(supported) == 0 {
+		return strings.EqualFold(requiredType, "SCSI")
+	}
+	for _, t := range supported {
+		if strings.EqualFold(t, requiredType) {
+			return true
+		}
+	}
+	return false
 }
 
 func getAzureVMSKUs(ctx context.Context, args *cr.ComputeRequestArgs) ([]string, error) {

--- a/pkg/provider/azure/data/compute-request.go
+++ b/pkg/provider/azure/data/compute-request.go
@@ -3,7 +3,6 @@ package data
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"slices"
 	"strconv"
@@ -13,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	cr "github.com/redhat-developer/mapt/pkg/provider/api/compute-request"
+	"github.com/redhat-developer/mapt/pkg/util/logging"
 )
 
 const (
@@ -112,12 +112,77 @@ func diskControllerTypeSupported(supported []string, requiredType string) bool {
 	return false
 }
 
+// FilterNoLocalStorageSizes returns only the sizes from computeSizes that have no
+// NVMe-only local storage (L-series). Temp disks (MaxResourceVolumeMB > 0) are allowed
+// — they are ephemeral scratch space that does not interfere with RHEL AI's OS disk.
+// Sizes not found in the Azure SKU catalog (typo or restricted SKU) are logged as
+// warnings and excluded.
+func FilterNoLocalStorageSizes(ctx context.Context, computeSizes []string) ([]string, error) {
+	creds, subscriptionID, err := getCredentials()
+	if err != nil {
+		return nil, err
+	}
+	client, err := armcompute.NewResourceSKUsClient(*subscriptionID, creds, nil)
+	if err != nil {
+		return nil, err
+	}
+	pager := client.NewListPager(nil)
+	capabilities := make(map[string]*virtualMachine, len(computeSizes))
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, sku := range page.Value {
+			if sku.ResourceType == nil || *sku.ResourceType != string(RTVirtualMachines) {
+				continue
+			}
+			if sku.Name == nil || !slices.Contains(computeSizes, *sku.Name) {
+				continue
+			}
+			if _, seen := capabilities[*sku.Name]; seen {
+				continue
+			}
+			if vm := resourceSKUToVirtualMachine(sku); vm != nil {
+				capabilities[*sku.Name] = vm
+			}
+		}
+	}
+	valid, dropped, unknown := filterNVMeStorage(computeSizes, capabilities)
+	for _, size := range dropped {
+		logging.Warnf("dropping compute size %q: has NVMe-only local storage, incompatible with RHEL AI", size)
+	}
+	for _, size := range unknown {
+		logging.Warnf("dropping compute size %q: not found in Azure SKU catalog (typo or restricted SKU)", size)
+	}
+	return valid, nil
+}
+
+// filterNVMeStorage classifies each size into valid (no NVMe-only local storage),
+// dropped (has NVMe local storage — e.g. L-series), or unknown (absent from capabilities).
+func filterNVMeStorage(computeSizes []string, capabilities map[string]*virtualMachine) (valid, dropped, unknown []string) {
+	for _, size := range computeSizes {
+		vm, ok := capabilities[size]
+		if !ok {
+			unknown = append(unknown, size)
+			continue
+		}
+		if vm.NvmeDiskSizeInMiB > 0 {
+			dropped = append(dropped, size)
+		} else {
+			valid = append(valid, size)
+		}
+	}
+	return valid, dropped, unknown
+}
+
 func getAzureVMSKUs(ctx context.Context, args *cr.ComputeRequestArgs) ([]string, error) {
+	ensureAzureEnvs()
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, err
 	}
-	subscriptionId := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	subscriptionId := SubscriptionID()
 	clientFactory, err := armcompute.NewClientFactory(
 		subscriptionId, cred, nil)
 	if err != nil {
@@ -156,6 +221,10 @@ type virtualMachine struct {
 	LowPriorityCapable  bool
 	MaxResourceVolumeMB int32
 	GPUs                int32
+	// L-series VMs expose NVMe storage separately from the temp disk
+	NvmeDiskSizeInMiB int32
+	// Used by the disk-controller-type fix (PR #823) to cross-reference SKU capabilities
+	DiskControllerTypes []string
 	// IaaS or PaaS
 	VMDeploymentTypes []string
 	// Fast SSD
@@ -191,17 +260,17 @@ func (vm *virtualMachine) hypervGen2Supported() bool {
 	return slices.Contains(vm.HyperVGenerations, "V2")
 }
 
-func (vm *virtualMachine) emptyDiskSupported() bool {
-	return vm.MaxResourceVolumeMB == 0
+func (vm *virtualMachine) noLocalStorageAttached() bool {
+	return vm.MaxResourceVolumeMB == 0 && vm.NvmeDiskSizeInMiB == 0
 }
 
 func (vm *virtualMachine) baseFeaturesSupported() bool {
 	return vm.AcceleratedNetworkingEnabled && vm.PremiumIO && vm.EncryptionAtHostSupported &&
-		vm.emptyDiskSupported() && vm.hypervGen2Supported()
+		vm.noLocalStorageAttached() && vm.hypervGen2Supported()
 }
 
 func resourceSKUToVirtualMachine(res *armcompute.ResourceSKU) *virtualMachine {
-	if res.ResourceType != nil && *res.ResourceType != "virtualMachines" {
+	if res.ResourceType != nil && *res.ResourceType != string(RTVirtualMachines) {
 		return nil
 	}
 	// If Machine type has any type of restriccions discard
@@ -272,6 +341,14 @@ func resourceSKUToVirtualMachine(res *armcompute.ResourceSKU) *virtualMachine {
 				return nil
 			}
 			vm.GPUs = int32(gpus)
+		case "NvmeDiskSizeInMiB":
+			nvme, err := strconv.ParseUint(*capability.Value, 10, 32)
+			if err != nil {
+				return nil
+			}
+			vm.NvmeDiskSizeInMiB = int32(nvme)
+		case "DiskControllerTypes":
+			vm.DiskControllerTypes = strings.Split(*capability.Value, ",")
 		case "VMDeploymentTypes":
 			vm.VMDeploymentTypes = strings.Split(*capability.Value, ",")
 		default:

--- a/pkg/provider/azure/data/compute-request_test.go
+++ b/pkg/provider/azure/data/compute-request_test.go
@@ -1,0 +1,183 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+// noLocalStorageAttached tests
+
+func TestNoLocalStorageAttached_NoTempDiskNoNvme(t *testing.T) {
+	vm := &virtualMachine{MaxResourceVolumeMB: 0, NvmeDiskSizeInMiB: 0}
+	if !vm.noLocalStorageAttached() {
+		t.Error("expected true: VM with no temp disk and no NVMe should have no local storage")
+	}
+}
+
+func TestNoLocalStorageAttached_HasTempDisk(t *testing.T) {
+	vm := &virtualMachine{MaxResourceVolumeMB: 512, NvmeDiskSizeInMiB: 0}
+	if vm.noLocalStorageAttached() {
+		t.Error("expected false: VM with temp disk should have local storage")
+	}
+}
+
+func TestNoLocalStorageAttached_HasNvmeDisk(t *testing.T) {
+	// L-series bug case: MaxResourceVolumeMB=0 but NvmeDiskSizeInMiB>0
+	vm := &virtualMachine{MaxResourceVolumeMB: 0, NvmeDiskSizeInMiB: 5492736}
+	if vm.noLocalStorageAttached() {
+		t.Error("expected false: L-series VM with NVMe storage should have local storage")
+	}
+}
+
+func TestNoLocalStorageAttached_HasBoth(t *testing.T) {
+	vm := &virtualMachine{MaxResourceVolumeMB: 512, NvmeDiskSizeInMiB: 5492736}
+	if vm.noLocalStorageAttached() {
+		t.Error("expected false: VM with both temp disk and NVMe should have local storage")
+	}
+}
+
+// resourceSKUToVirtualMachine parsing tests
+
+func TestResourceSKUToVirtualMachine_ParsesNvmeDiskSizeInMiB(t *testing.T) {
+	sku := &armcompute.ResourceSKU{
+		ResourceType: ptr("virtualMachines"),
+		Name:         ptr("Standard_L8aos_v4"),
+		Family:       ptr("standardLasv4Family"),
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
+			{Name: ptr("NvmeDiskSizeInMiB"), Value: ptr("5492736")},
+		},
+	}
+	vm := resourceSKUToVirtualMachine(sku)
+	if vm == nil {
+		t.Fatal("expected non-nil virtualMachine")
+	}
+	if vm.NvmeDiskSizeInMiB != 5492736 {
+		t.Errorf("NvmeDiskSizeInMiB: got %d, want 5492736", vm.NvmeDiskSizeInMiB)
+	}
+}
+
+func TestResourceSKUToVirtualMachine_ParsesDiskControllerTypes(t *testing.T) {
+	sku := &armcompute.ResourceSKU{
+		ResourceType: ptr("virtualMachines"),
+		Name:         ptr("Standard_L8aos_v4"),
+		Family:       ptr("standardLasv4Family"),
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
+			{Name: ptr("DiskControllerTypes"), Value: ptr("NVMe,SCSI")},
+		},
+	}
+	vm := resourceSKUToVirtualMachine(sku)
+	if vm == nil {
+		t.Fatal("expected non-nil virtualMachine")
+	}
+	if len(vm.DiskControllerTypes) != 2 {
+		t.Fatalf("DiskControllerTypes: got %v, want [NVMe SCSI]", vm.DiskControllerTypes)
+	}
+	if vm.DiskControllerTypes[0] != "NVMe" || vm.DiskControllerTypes[1] != "SCSI" {
+		t.Errorf("DiskControllerTypes: got %v, want [NVMe SCSI]", vm.DiskControllerTypes)
+	}
+}
+
+func TestResourceSKUToVirtualMachine_NvmeDiskSizeDefaultsToZero(t *testing.T) {
+	sku := &armcompute.ResourceSKU{
+		ResourceType: ptr("virtualMachines"),
+		Name:         ptr("Standard_D8as_v5"),
+		Family:       ptr("standardDasv5Family"),
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
+			{Name: ptr("MaxResourceVolumeMB"), Value: ptr("307200")},
+		},
+	}
+	vm := resourceSKUToVirtualMachine(sku)
+	if vm == nil {
+		t.Fatal("expected non-nil virtualMachine")
+	}
+	if vm.NvmeDiskSizeInMiB != 0 {
+		t.Errorf("NvmeDiskSizeInMiB: got %d, want 0 for non-NVMe SKU", vm.NvmeDiskSizeInMiB)
+	}
+}
+
+// filterNVMeStorage tests
+
+func TestFilterNVMeStorage_DropsNvmeSizes(t *testing.T) {
+	capabilities := map[string]*virtualMachine{
+		"Standard_D8as_v5":  {MaxResourceVolumeMB: 0, NvmeDiskSizeInMiB: 0},
+		"Standard_L8aos_v4": {MaxResourceVolumeMB: 0, NvmeDiskSizeInMiB: 5492736},
+	}
+	got, dropped, unknown := filterNVMeStorage([]string{"Standard_D8as_v5", "Standard_L8aos_v4"}, capabilities)
+	if len(got) != 1 || got[0] != "Standard_D8as_v5" {
+		t.Errorf("filtered: got %v, want [Standard_D8as_v5]", got)
+	}
+	if len(dropped) != 1 || dropped[0] != "Standard_L8aos_v4" {
+		t.Errorf("dropped: got %v, want [Standard_L8aos_v4]", dropped)
+	}
+	if len(unknown) != 0 {
+		t.Errorf("unknown: got %v, want []", unknown)
+	}
+}
+
+func TestFilterNVMeStorage_AllowsTempDiskSizes(t *testing.T) {
+	capabilities := map[string]*virtualMachine{
+		"Standard_NC64as_T4_v3": {MaxResourceVolumeMB: 32768, NvmeDiskSizeInMiB: 0},
+	}
+	got, dropped, unknown := filterNVMeStorage([]string{"Standard_NC64as_T4_v3"}, capabilities)
+	if len(got) != 1 {
+		t.Errorf("filtered: got %v, want [Standard_NC64as_T4_v3]", got)
+	}
+	if len(dropped) != 0 {
+		t.Errorf("dropped: got %v, want []", dropped)
+	}
+	if len(unknown) != 0 {
+		t.Errorf("unknown: got %v, want []", unknown)
+	}
+}
+
+func TestFilterNVMeStorage_PassesCleanSizes(t *testing.T) {
+	capabilities := map[string]*virtualMachine{
+		"Standard_D8as_v5": {MaxResourceVolumeMB: 0, NvmeDiskSizeInMiB: 0},
+	}
+	got, dropped, unknown := filterNVMeStorage([]string{"Standard_D8as_v5"}, capabilities)
+	if len(got) != 1 {
+		t.Errorf("filtered: got %v, want [Standard_D8as_v5]", got)
+	}
+	if len(dropped) != 0 {
+		t.Errorf("dropped: got %v, want []", dropped)
+	}
+	if len(unknown) != 0 {
+		t.Errorf("unknown: got %v, want []", unknown)
+	}
+}
+
+func TestFilterNVMeStorage_ReportsUnknownSizes(t *testing.T) {
+	capabilities := map[string]*virtualMachine{
+		"Standard_D8as_v5": {MaxResourceVolumeMB: 0, NvmeDiskSizeInMiB: 0},
+	}
+	got, dropped, unknown := filterNVMeStorage(
+		[]string{"Standard_D8as_v5", "Standard_Typo_v99"}, capabilities)
+	if len(got) != 1 || got[0] != "Standard_D8as_v5" {
+		t.Errorf("filtered: got %v, want [Standard_D8as_v5]", got)
+	}
+	if len(dropped) != 0 {
+		t.Errorf("dropped: got %v, want []", dropped)
+	}
+	if len(unknown) != 1 || unknown[0] != "Standard_Typo_v99" {
+		t.Errorf("unknown: got %v, want [Standard_Typo_v99]", unknown)
+	}
+}
+
+// baseFeaturesSupported regression: L-series must be rejected
+
+func TestBaseFeaturesSupported_LSeriesWithNvmeIsRejected(t *testing.T) {
+	vm := &virtualMachine{
+		MaxResourceVolumeMB:          0,
+		NvmeDiskSizeInMiB:            5492736,
+		AcceleratedNetworkingEnabled: true,
+		PremiumIO:                    true,
+		EncryptionAtHostSupported:    true,
+		HyperVGenerations:            []string{"V1", "V2"},
+	}
+	if vm.baseFeaturesSupported() {
+		t.Error("expected false: L-series VM with NVMe storage must not pass baseFeaturesSupported")
+	}
+}

--- a/pkg/provider/azure/data/imageref.go
+++ b/pkg/provider/azure/data/imageref.go
@@ -28,8 +28,11 @@ type ImageReference struct {
 	Sku       string
 	// Community
 	CommunityImageID string
-	// // Private Shared
+	// Private Shared
 	SharedImageID string
+	// Required disk controller type for this image (e.g. "SCSI", "NVMe").
+	// Empty means no specific requirement; Azure uses the VM size default.
+	DiskControllerType string
 }
 
 var (

--- a/pkg/provider/azure/data/images.go
+++ b/pkg/provider/azure/data/images.go
@@ -3,7 +3,6 @@ package data
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -16,11 +15,12 @@ type ImageRequest struct {
 }
 
 func IsImageOffered(ctx context.Context, req ImageRequest) error {
+	ensureAzureEnvs()
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return err
 	}
-	subscriptionId := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	subscriptionId := SubscriptionID()
 	clientFactory, err := armcompute.NewClientFactory(subscriptionId, cred, nil)
 	if err != nil {
 		return err
@@ -53,11 +53,12 @@ func getCommunityImage(ctx context.Context, c *armcompute.ClientFactory, id, reg
 }
 
 func GetSharedImage(ctx context.Context, id *string) (*armcompute.GalleryImageVersionsClientGetResponse, error) {
+	ensureAzureEnvs()
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, err
 	}
-	subscriptionId := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	subscriptionId := SubscriptionID()
 	c, err := armcompute.NewClientFactory(subscriptionId, cred, nil)
 	if err != nil {
 		return nil, err
@@ -120,11 +121,12 @@ func GetSharedImageDiskControllerTypes(ctx context.Context, id *string) ([]strin
 }
 
 func SkuG2Support(ctx context.Context, location string, publisher string, offer string, sku string) (string, error) {
+	ensureAzureEnvs()
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return "", err
 	}
-	subscriptionId := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	subscriptionId := SubscriptionID()
 
 	clientFactory, err := armcompute.NewClientFactory(subscriptionId, cred, nil)
 	if err != nil {

--- a/pkg/provider/azure/data/images.go
+++ b/pkg/provider/azure/data/images.go
@@ -85,6 +85,40 @@ func getSharedImage(ctx context.Context, c *armcompute.ClientFactory, id *string
 	return &res, nil
 }
 
+// GetSharedImageDiskControllerTypes returns the disk controller types listed in the
+// gallery image definition's features (e.g. ["SCSI"] for RHEL AI images). Returns nil
+// when the feature is absent. Uses the gallery owner's subscription (parts[2] of the
+// ARM resource ID) so the API path resolves to where the resource actually lives.
+// The image ID must be a full ARM resource ID with 13 slash-separated parts.
+func GetSharedImageDiskControllerTypes(ctx context.Context, id *string) ([]string, error) {
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(*id, "/")
+	if len(parts) != 13 {
+		return nil, fmt.Errorf("invalid shared image ID: %s", *id)
+	}
+	c, err := armcompute.NewClientFactory(parts[2], cred, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Query the image definition, not the version — Features live on the definition.
+	res, err := c.NewGalleryImagesClient().Get(ctx, parts[4], parts[8], parts[10], nil)
+	if err != nil {
+		return nil, err
+	}
+	if res.Properties == nil {
+		return nil, nil
+	}
+	for _, f := range res.Properties.Features {
+		if f.Name != nil && *f.Name == "DiskControllerTypes" && f.Value != nil {
+			return splitDiskControllerTypes(*f.Value), nil
+		}
+	}
+	return nil, nil
+}
+
 func SkuG2Support(ctx context.Context, location string, publisher string, offer string, sku string) (string, error) {
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {

--- a/pkg/provider/azure/data/util.go
+++ b/pkg/provider/azure/data/util.go
@@ -8,16 +8,42 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 )
 
-const (
-	ENV_AZURE_SUBSCRIPTION_ID = "AZURE_SUBSCRIPTION_ID"
-)
+var azureIdentityEnvs = []string{
+	"AZURE_TENANT_ID",
+	"AZURE_SUBSCRIPTION_ID",
+	"AZURE_CLIENT_ID",
+	"AZURE_CLIENT_SECRET",
+}
+
+// ensureAzureEnvs maps ARM_* env vars to AZURE_* if the AZURE_* vars are unset.
+// Safe to call multiple times — only sets vars that are currently empty.
+func ensureAzureEnvs() {
+	for _, e := range azureIdentityEnvs {
+		if os.Getenv(e) == "" {
+			armKey := strings.ReplaceAll(e, "AZURE", "ARM")
+			if v := os.Getenv(armKey); v != "" {
+				_ = os.Setenv(e, v)
+			}
+		}
+	}
+}
+
+// SubscriptionID returns the Azure subscription ID, checking AZURE_SUBSCRIPTION_ID
+// first, then falling back to ARM_SUBSCRIPTION_ID (Pulumi/Terraform convention).
+func SubscriptionID() string {
+	if v := os.Getenv("AZURE_SUBSCRIPTION_ID"); v != "" {
+		return v
+	}
+	return os.Getenv("ARM_SUBSCRIPTION_ID")
+}
 
 func getCredentials() (cred *azidentity.DefaultAzureCredential, subscriptionID *string, err error) {
+	ensureAzureEnvs()
 	cred, err = azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return
 	}
-	azSubsID := os.Getenv(ENV_AZURE_SUBSCRIPTION_ID)
+	azSubsID := SubscriptionID()
 	subscriptionID = &azSubsID
 	return
 }
@@ -34,6 +60,7 @@ func splitDiskControllerTypes(s string) []string {
 }
 
 func getGraphClientFactory() (*armresourcegraph.ClientFactory, error) {
+	ensureAzureEnvs()
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/azure/data/util.go
+++ b/pkg/provider/azure/data/util.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"os"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
@@ -19,6 +20,17 @@ func getCredentials() (cred *azidentity.DefaultAzureCredential, subscriptionID *
 	azSubsID := os.Getenv(ENV_AZURE_SUBSCRIPTION_ID)
 	subscriptionID = &azSubsID
 	return
+}
+
+// splitDiskControllerTypes splits a comma-separated disk controller type string
+// (e.g. "SCSI,NVMe") and trims whitespace from each element.
+func splitDiskControllerTypes(s string) []string {
+	raw := strings.Split(s, ",")
+	out := make([]string, 0, len(raw))
+	for _, t := range raw {
+		out = append(out, strings.TrimSpace(t))
+	}
+	return out
 }
 
 func getGraphClientFactory() (*armresourcegraph.ClientFactory, error) {

--- a/pkg/provider/azure/data/vmsize.go
+++ b/pkg/provider/azure/data/vmsize.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"context"
-	"os"
 	"slices"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -17,12 +16,12 @@ func IsVMSizeOfferedByLocation(ctx context.Context, vmSize, location string) (bo
 
 // Get InstanceTypes offerings on current location
 func FilterVMSizeOfferedByLocation(ctx context.Context, vmSizes []string, location string) ([]string, error) {
-	// Create a new Azure credential (uses environment variables or managed identity)
+	ensureAzureEnvs()
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, err
 	}
-	subscriptionId := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	subscriptionId := SubscriptionID()
 	clientFactory, err := armcompute.NewClientFactory(subscriptionId, cred, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/azure/modules/allocation/allocation.go
+++ b/pkg/provider/azure/modules/allocation/allocation.go
@@ -7,6 +7,7 @@ import (
 	cr "github.com/redhat-developer/mapt/pkg/provider/api/compute-request"
 	spotTypes "github.com/redhat-developer/mapt/pkg/provider/api/spot"
 	"github.com/redhat-developer/mapt/pkg/provider/azure/data"
+	"github.com/redhat-developer/mapt/pkg/util/logging"
 )
 
 type AllocationArgs struct {
@@ -34,6 +35,17 @@ func Allocation(mCtx *mc.Context, args *AllocationArgs) (*AllocationResult, erro
 			return nil, err
 		}
 	}
+
+	// Derive the effective image reference. For shared gallery images, resolveImageRef
+	// queries the gallery API and sets DiskControllerType when the image supports
+	// exactly one type; the caller's explicit value is preserved in all other cases.
+	ir := resolveImageRef(mCtx, args.ImageRef)
+
+	diskControllerType := ""
+	if ir != nil {
+		diskControllerType = ir.DiskControllerType
+	}
+
 	if args.Spot != nil && args.Spot.Spot {
 		sArgs := &data.SpotInfoArgs{
 			ComputeSizes:          computeSizes,
@@ -42,15 +54,29 @@ func Allocation(mCtx *mc.Context, args *AllocationArgs) (*AllocationResult, erro
 			ExcludedLocations:     args.Spot.ExcludedHostingPlaces,
 			SpotPriceIncreaseRate: &args.Spot.IncreaseRate,
 		}
-		if args.ImageRef != nil {
-			sArgs.ImageRef = args.ImageRef
+		if ir != nil {
+			sArgs.ImageRef = ir
 		}
 		bsc, err := data.SpotInfo(mCtx, sArgs)
 		if err != nil {
 			return nil, err
 		}
+		// Filter the spot-selected sizes by disk controller type compatibility.
+		if diskControllerType != "" {
+			spotLocation := bsc.HostingPlace
+			bsc.ComputeType, err = data.FilterComputeSizesByDiskControllerType(
+				mCtx.Context(), &spotLocation, bsc.ComputeType, diskControllerType)
+			if err != nil {
+				return nil, err
+			}
+			if len(bsc.ComputeType) == 0 {
+				return nil, fmt.Errorf(
+					"spot compute sizes in location %q do not support disk controller type %q required by the selected image",
+					bsc.HostingPlace, diskControllerType)
+			}
+		}
 		return &AllocationResult{
-			ImageRef:     args.ImageRef,
+			ImageRef:     ir,
 			Location:     &bsc.HostingPlace,
 			Price:        &bsc.Price,
 			ComputeSizes: bsc.ComputeType,
@@ -65,20 +91,48 @@ func Allocation(mCtx *mc.Context, args *AllocationArgs) (*AllocationResult, erro
 			}
 			location = &hp
 		}
-		// Filter for current location the computesizes
-		supportedComputeSizes, err := data.FilterComputeSizesByLocation(
-			mCtx.Context(), location, computeSizes)
+		// Single SKU enumeration: filter by location and disk controller type together.
+		// When diskControllerType is empty the type check is a no-op (any type passes).
+		supportedComputeSizes, err := data.FilterComputeSizesByDiskControllerType(
+			mCtx.Context(), location, computeSizes, diskControllerType)
 		if err != nil {
 			return nil, err
 		}
 		if len(supportedComputeSizes) == 0 {
+			if diskControllerType != "" {
+				return nil, fmt.Errorf(
+					"no compute sizes in location %q support disk controller type %q required by the selected image",
+					*location, diskControllerType)
+			}
 			return nil, fmt.Errorf("no compute sizes available for location %q", *location)
 		}
 		return &AllocationResult{
-			ImageRef:     args.ImageRef,
+			ImageRef:     ir,
 			Location:     location,
 			ComputeSizes: supportedComputeSizes,
 		}, nil
-
 	}
+}
+
+// resolveImageRef returns a copy of the image reference, optionally enriched with the
+// disk controller type read from the gallery image definition. The gallery Features value
+// lists types the image *supports*, not what it *requires*. We only override the caller's
+// value when the gallery returns exactly one supported type — that uniquely identifies the
+// requirement. When the gallery returns multiple types the image is flexible, so the
+// caller's explicit value (if any) is preserved unchanged. On fetch failure the caller's
+// value is also preserved.
+func resolveImageRef(mCtx *mc.Context, ir *data.ImageReference) *data.ImageReference {
+	if ir == nil || ir.SharedImageID == "" {
+		return ir
+	}
+	enriched := *ir
+	types, err := data.GetSharedImageDiskControllerTypes(mCtx.Context(), &ir.SharedImageID)
+	if err != nil {
+		logging.Debugf("could not fetch disk controller types for image %s: %v", ir.SharedImageID, err)
+		return &enriched
+	}
+	if len(types) == 1 && enriched.DiskControllerType == "" {
+		enriched.DiskControllerType = types[0]
+	}
+	return &enriched
 }

--- a/pkg/provider/azure/modules/virtual-machine/virtual-machine.go
+++ b/pkg/provider/azure/modules/virtual-machine/virtual-machine.go
@@ -2,7 +2,6 @@ package virtualmachine
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/pulumi/pulumi-azure-native-sdk/compute/v3"
@@ -162,7 +161,7 @@ func convertImageRef(mCtx *mc.Context, i data.ImageReference, location string) (
 
 func isSelfOwned(sharedImageId *string) bool {
 	sharedImageParams := strings.Split(*sharedImageId, "/")
-	return os.Getenv("AZURE_SUBSCRIPTION_ID") == sharedImageParams[2]
+	return data.SubscriptionID() == sharedImageParams[2]
 }
 
 func diskControllerTypePtr(t string) pulumi.StringPtrInput {

--- a/pkg/provider/azure/modules/virtual-machine/virtual-machine.go
+++ b/pkg/provider/azure/modules/virtual-machine/virtual-machine.go
@@ -82,6 +82,7 @@ func Create(ctx *pulumi.Context, mCtx *mc.Context, args *VirtualMachineArgs) (Vi
 					StorageAccountType: pulumi.String("Standard_LRS"),
 				},
 			},
+			DiskControllerType: diskControllerTypePtr(args.Image.DiskControllerType),
 		},
 		// Try to improve provisioning time
 		DiagnosticsProfile: compute.DiagnosticsProfileArgs{
@@ -162,4 +163,11 @@ func convertImageRef(mCtx *mc.Context, i data.ImageReference, location string) (
 func isSelfOwned(sharedImageId *string) bool {
 	sharedImageParams := strings.Split(*sharedImageId, "/")
 	return os.Getenv("AZURE_SUBSCRIPTION_ID") == sharedImageParams[2]
+}
+
+func diskControllerTypePtr(t string) pulumi.StringPtrInput {
+	if t == "" {
+		return nil
+	}
+	return pulumi.StringPtr(t)
 }


### PR DESCRIPTION
## Summary

Combines three related Azure RHEL AI fixes into a single PR (per reviewer request). These were discovered and validated during end-to-end testing with Claudio.

**Commit 1 — Disk controller type (was #823):** RHEL AI gallery images require SCSI but mapt never set it explicitly, letting Azure infer a conflicting default on some VM sizes. Now sets `DiskControllerType: "SCSI"` in `ImageReference` and validates against the gallery image's features.

**Commit 2 — GPU guardrails (was #825):** Spot allocation could pick non-GPU VMs for RHEL AI, causing vllm to fail silently. Adds `isGPUCapableSize()` validation (ND/NC-series only) and defaults `GPUs=1` when unset.

**Commit 3 — NVMe filter + credential handling (was #824):** L-series VMs bypassed the local storage filter via NVMe capability. Also fixes credential resolution (`ARM_*` → `AZURE_*` mapping) for code paths that run before `provider.Init()`.

Supersedes #823, #824, #825.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>