### PR TITLE
fix(rhel-ai): fix rhel-ai on demand EIP creation

### DIFF
--- a/pkg/provider/aws/action/rhel-ai/rhelai.go
+++ b/pkg/provider/aws/action/rhel-ai/rhelai.go
@@ -161,8 +161,8 @@ func (r *rhelAIRequest) deploy(ctx *pulumi.Context) error {
 			ID:                 awsRHELDedicatedID,
 			Region:             *r.allocationData.Region,
 			AZ:                 *r.allocationData.AZ,
-			CreateLoadBalancer: true,
-			ServiceEndpoints:          r.serviceEndpoints,
+			CreateLoadBalancer: r.allocationData.SpotPrice != nil,
+			ServiceEndpoints:   r.serviceEndpoints,
 		})
 	if err != nil {
 		return err


### PR DESCRIPTION
previously we had craete load balancer fixed to true in rhel-ai (this is required for spot) but it should be false for on demand, this commit ensures it is created based on the type of provisioning