### PR TITLE
AIPCC:15489: Add support for Gaudi accelerator in mapt's IBM Cloud module

### DIFF
--- a/cmd/mapt/cmd/ibmcloud/hosts/ibm-gaudi.go
+++ b/cmd/mapt/cmd/ibmcloud/hosts/ibm-gaudi.go
@@ -1,0 +1,104 @@
+package hosts
+
+import (
+	"github.com/redhat-developer/mapt/cmd/mapt/cmd/params"
+	maptContext "github.com/redhat-developer/mapt/pkg/manager/context"
+	ibmgaudi "github.com/redhat-developer/mapt/pkg/provider/ibmcloud/action/ibm-gaudi"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+const (
+	cmdIBMGaudi     = "ibm-gaudi"
+	cmdIBMGaudiDesc = "manage ibm gaudi3 accelerated instances (amd64)"
+)
+
+func IBMGaudiCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   cmdIBMGaudi,
+		Short: cmdIBMGaudiDesc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := viper.BindPFlags(cmd.Flags()); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	flagSet := pflag.NewFlagSet(cmdIBMGaudi, pflag.ExitOnError)
+	params.AddCommonFlags(flagSet)
+	c.PersistentFlags().AddFlagSet(flagSet)
+
+	c.AddCommand(ibmGaudiCreate(), ibmGaudiDestroy())
+	return c
+}
+
+func ibmGaudiCreate() *cobra.Command {
+	c := &cobra.Command{
+		Use:   params.CreateCmdName,
+		Short: params.CreateCmdName,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := viper.BindPFlags(cmd.Flags()); err != nil {
+				return err
+			}
+			return ibmgaudi.New(
+				&maptContext.ContextArgs{
+					Context:       cmd.Context(),
+					ProjectName:   viper.GetString(params.ProjectName),
+					BackedURL:     viper.GetString(params.BackedURL),
+					ResultsOutput: viper.GetString(params.ConnectionDetailsOutput),
+					Debug:         viper.IsSet(params.Debug),
+					DebugLevel:    viper.GetUint(params.DebugLevel),
+					Tags:          viper.GetStringMapString(params.Tags),
+				},
+				&ibmgaudi.GaudiArgs{
+					SubnetID:       viper.GetString(params.SubnetID),
+					OtelAppCode:    viper.GetString(params.OtelAppCode),
+					OtelAuthToken:  viper.GetString(params.OtelAuthToken),
+					OtelEndpoint:   viper.GetString(params.OtelEndpoint),
+					OtelIndex:      viper.GetString(params.OtelIndex),
+					OtelExtraAttrs: viper.GetStringMapString(params.OtelExtraAttrs),
+				})
+		},
+	}
+	flagSet := pflag.NewFlagSet(params.CreateCmdName, pflag.ExitOnError)
+	flagSet.StringP(params.ConnectionDetailsOutput, "", "", params.ConnectionDetailsOutputDesc)
+	flagSet.StringToStringP(params.Tags, "", nil, params.TagsDesc)
+	flagSet.StringP(params.SubnetID, "", "", params.SubnetIDDesc)
+	flagSet.StringP(params.OtelAppCode, "", "", params.OtelAppCodeDesc)
+	flagSet.StringP(params.OtelAuthToken, "", "", params.OtelAuthTokenDesc)
+	flagSet.StringP(params.OtelEndpoint, "", "https://otel-input.corp.redhat.com", params.OtelEndpointDesc)
+	flagSet.StringP(params.OtelIndex, "", "", params.OtelIndexDesc)
+	flagSet.StringToStringP(params.OtelExtraAttrs, "", nil, params.OtelExtraAttrsDesc)
+	c.PersistentFlags().AddFlagSet(flagSet)
+	return c
+}
+
+func ibmGaudiDestroy() *cobra.Command {
+	c := &cobra.Command{
+		Use:   params.DestroyCmdName,
+		Short: params.DestroyCmdName,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := viper.BindPFlags(cmd.Flags()); err != nil {
+				return err
+			}
+			return ibmgaudi.Destroy(&maptContext.ContextArgs{
+				Context:      cmd.Context(),
+				ProjectName:  viper.GetString(params.ProjectName),
+				BackedURL:    viper.GetString(params.BackedURL),
+				Debug:        viper.IsSet(params.Debug),
+				DebugLevel:   viper.GetUint(params.DebugLevel),
+				Serverless:   viper.IsSet(params.Serverless),
+				ForceDestroy: viper.IsSet(params.ForceDestroy),
+				KeepState:    viper.IsSet(params.KeepState),
+			})
+		},
+	}
+	flagSet := pflag.NewFlagSet(params.DestroyCmdName, pflag.ExitOnError)
+	flagSet.Bool(params.Serverless, false, params.ServerlessDesc)
+	flagSet.Bool(params.ForceDestroy, false, params.ForceDestroyDesc)
+	flagSet.Bool(params.KeepState, false, params.KeepStateDesc)
+	c.PersistentFlags().AddFlagSet(flagSet)
+	return c
+}

--- a/cmd/mapt/cmd/ibmcloud/ibmcloud.go
+++ b/cmd/mapt/cmd/ibmcloud/ibmcloud.go
@@ -29,6 +29,7 @@ func GetCmd() *cobra.Command {
 	params.AddCommonFlags(flagSet)
 	c.PersistentFlags().AddFlagSet(flagSet)
 	c.AddCommand(
+		hosts.IBMGaudiCmd(),
 		hosts.IBMPowerCmd(),
 		hosts.IBMZCmd())
 	return c

--- a/docs/ibmcloud/ibm-gaudi.md
+++ b/docs/ibmcloud/ibm-gaudi.md
@@ -1,0 +1,167 @@
+# Overview
+
+This action provisions an Intel Gaudi 3 accelerated instance on IBM Cloud VPC using the RHEL AI image. The instance uses the `gx3d-160x1792x8gaudi3` profile (160 vCPU, 1792 GB RAM, 8x Gaudi 3 accelerators) and is assigned a floating IP for direct SSH access.
+
+Two networking modes are supported:
+
+- **Existing subnet** (`--subnet-id`): the instance is placed in a pre-existing VPC subnet. VPC, subnet, and gateway are not created. Only `IC_REGION` is required.
+- **Auto-provision** (no `--subnet-id`): a new VPC, subnet, and public gateway are created from scratch. Both `IC_REGION` and `IC_ZONE` are required.
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `IBMCLOUD_ACCOUNT` | yes | IBM Cloud account ID |
+| `IBMCLOUD_API_KEY` | yes | IBM Cloud API key |
+| `IC_REGION` | yes | IBM Cloud region (e.g. `us-east`, `us-south`, `eu-de`) |
+| `IC_ZONE` | only without `--subnet-id` | Availability zone (e.g. `us-east-1`) |
+| `IBMCLOUD_COS_ACCESS_KEY_ID` | only with S3 `--backed-url` | HMAC access key for IBM Cloud Object Storage |
+| `IBMCLOUD_COS_SECRET_ACCESS_KEY` | only with S3 `--backed-url` | HMAC secret key for IBM Cloud Object Storage |
+| `IBMCLOUD_COS_ENDPOINT` | no | COS S3 endpoint (defaults to `s3.<region>.cloud-object-storage.appdomain.cloud`) |
+
+## Regional availability
+
+Gaudi 3 instances are available in:
+
+- **us-east** (Washington DC)
+- **us-south** (Dallas)
+- **eu-de** (Frankfurt)
+
+## Create
+
+```bash
+mapt ibmcloud ibm-gaudi create -h
+create
+
+Usage:
+  mapt ibmcloud ibm-gaudi create [flags]
+
+Flags:
+      --conn-details-output string           path to export host connection information (host, username and privateKey)
+  -h, --help                                 help for create
+      --otel-app-code string                 OpenTelemetry appcode identifier (e.g. MAPT-001); when set together with --otel-auth-token, installs the otelcol-contrib filelog collector on the instance
+      --otel-auth-token string               OpenTelemetry authentication token (UUID) used to authenticate against the OTLP endpoint
+      --otel-endpoint string                 OTLP HTTP endpoint to export logs to (default "https://otel-input.corp.redhat.com")
+      --otel-index string                    Splunk index name for log routing (e.g. rh_linux)
+      --subnet-id string                     ID of an existing VPC subnet to deploy the instance into (optional)
+      --tags stringToString                  tags to add on each resource (--tags name1=value1,name2=value2) (default [])
+
+Global Flags:
+      --backed-url string     backed for stack state. (local) file:///path/subpath (s3) s3://existing-bucket, (azure) azblob://existing-blobcontainer. See more https://www.pulumi.com/docs/iac/concepts/state-and-backends/#using-a-self-managed-backend
+      --debug                 Enable debug traces and set verbosity to max. Typically to get information to troubleshooting an issue.
+      --debug-level uint      Set the level of verbosity on debug. You can set from minimum 1 to max 9. (default 3)
+      --project-name string   project name to identify the instance of the stack
+```
+
+### Outputs
+
+Files written to the path defined by `--conn-details-output`:
+
+| File | Description |
+|---|---|
+| `host` | Floating IP of the instance (direct SSH) |
+| `username` | SSH username (`cloud-user`) |
+| `id_rsa` | Private key for the instance |
+
+A state folder is also created at `--backed-url`. It is required (together with `--project-name`) to destroy the resources later.
+
+### SSH access
+
+```bash
+OUTPUT=/path/to/conn-details-output
+
+ssh -i ${OUTPUT}/id_rsa \
+    -o StrictHostKeyChecking=no \
+    cloud-user@$(cat ${OUTPUT}/host)
+```
+
+### Container
+
+```bash
+# Using an existing VPC subnet
+podman run -d --name ibm-gaudi \
+        -v ${PWD}:/workspace:z \
+        -e IBMCLOUD_API_KEY=XXX \
+        -e IC_REGION=us-east \
+        quay.io/redhat-developer/mapt:latest ibmcloud ibm-gaudi create \
+            --project-name ibm-gaudi \
+            --backed-url file:///workspace \
+            --conn-details-output /workspace \
+            --subnet-id <subnet-id>
+
+# Auto-provisioning VPC, subnet, and gateway
+podman run -d --name ibm-gaudi \
+        -v ${PWD}:/workspace:z \
+        -e IBMCLOUD_API_KEY=XXX \
+        -e IC_REGION=us-east \
+        -e IC_ZONE=us-east-1 \
+        quay.io/redhat-developer/mapt:latest ibmcloud ibm-gaudi create \
+            --project-name ibm-gaudi \
+            --backed-url file:///workspace \
+            --conn-details-output /workspace
+```
+
+## OpenTelemetry log collection
+
+When both `--otel-app-code` and `--otel-auth-token` are provided, cloud-init installs `otelcol-contrib` on the instance at first boot and configures it to ship `/var/log/messages`, `/var/log/secure`, and `/var/log/audit/audit.log` to the OTLP endpoint.
+
+```bash
+podman run -d --name ibm-gaudi \
+        -v ${PWD}:/workspace:z \
+        -e IBMCLOUD_API_KEY=XXX \
+        -e IC_REGION=us-east \
+        quay.io/redhat-developer/mapt:latest ibmcloud ibm-gaudi create \
+            --project-name ibm-gaudi \
+            --backed-url file:///workspace \
+            --conn-details-output /workspace \
+            --subnet-id <subnet-id> \
+            --otel-app-code MAPT-001 \
+            --otel-auth-token <uuid-token>
+```
+
+## Using IBM Cloud Object Storage as S3 backend
+
+To store Pulumi state in IBM COS instead of a local file, create [HMAC credentials](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-uhc-hmac-credentials-main) for your COS instance and pass an `s3://` backed URL:
+
+```bash
+podman run -d --name ibm-gaudi \
+        -v ${PWD}:/workspace:z \
+        -e IBMCLOUD_API_KEY=XXX \
+        -e IBMCLOUD_ACCOUNT=XXX \
+        -e IC_REGION=us-east \
+        -e IC_ZONE=us-east-1 \
+        -e IBMCLOUD_COS_ACCESS_KEY_ID=XXX \
+        -e IBMCLOUD_COS_SECRET_ACCESS_KEY=XXX \
+        quay.io/redhat-developer/mapt:latest ibmcloud ibm-gaudi create \
+            --project-name ibm-gaudi \
+            --backed-url s3://my-cos-bucket \
+            --conn-details-output /workspace
+```
+
+## Destroy
+
+```bash
+podman run -d --name ibm-gaudi \
+        -v ${PWD}:/workspace:z \
+        -e IBMCLOUD_API_KEY=XXX \
+        -e IC_REGION=us-east \
+        quay.io/redhat-developer/mapt:latest ibmcloud ibm-gaudi destroy \
+            --project-name ibm-gaudi \
+            --backed-url file:///workspace
+```
+
+By default, destroy removes the Pulumi state files from the backend after a successful destroy. Use `--keep-state` to preserve them:
+
+```bash
+podman run -d --name ibm-gaudi \
+        -v ${PWD}:/workspace:z \
+        -e IBMCLOUD_API_KEY=XXX \
+        -e IBMCLOUD_ACCOUNT=XXX \
+        -e IC_REGION=us-east \
+        -e IBMCLOUD_COS_ACCESS_KEY_ID=XXX \
+        -e IBMCLOUD_COS_SECRET_ACCESS_KEY=XXX \
+        quay.io/redhat-developer/mapt:latest ibmcloud ibm-gaudi destroy \
+            --project-name ibm-gaudi \
+            --backed-url s3://my-cos-bucket \
+            --keep-state
+```

--- a/pkg/provider/ibmcloud/action/ibm-gaudi/cloud-config
+++ b/pkg/provider/ibmcloud/action/ibm-gaudi/cloud-config
@@ -1,0 +1,11 @@
+#cloud-config
+{{- if .OtelColScript}}
+write_files:
+  - path: /opt/install-otelcol.sh
+    permissions: '0700'
+    owner: root:root
+    content: |
+{{.OtelColScript}}
+runcmd:
+  - bash /opt/install-otelcol.sh
+{{- end}}

--- a/pkg/provider/ibmcloud/action/ibm-gaudi/ibm-gaudi.go
+++ b/pkg/provider/ibmcloud/action/ibm-gaudi/ibm-gaudi.go
@@ -1,0 +1,415 @@
+package ibmgaudi
+
+import (
+	_ "embed"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/mapt-oss/pulumi-ibmcloud/sdk/go/ibmcloud"
+	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
+	"github.com/pulumi/pulumi-tls/sdk/v5/go/tls"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/redhat-developer/mapt/pkg/integrations/otelcol"
+	"github.com/redhat-developer/mapt/pkg/manager"
+	mc "github.com/redhat-developer/mapt/pkg/manager/context"
+	ibmcloudp "github.com/redhat-developer/mapt/pkg/provider/ibmcloud"
+	icdata "github.com/redhat-developer/mapt/pkg/provider/ibmcloud/data"
+	"github.com/redhat-developer/mapt/pkg/provider/ibmcloud/modules/network"
+	"github.com/redhat-developer/mapt/pkg/provider/util/command"
+	"github.com/redhat-developer/mapt/pkg/provider/util/output"
+	"github.com/redhat-developer/mapt/pkg/util"
+	"github.com/redhat-developer/mapt/pkg/util/file"
+	"github.com/redhat-developer/mapt/pkg/util/logging"
+	resourcesUtil "github.com/redhat-developer/mapt/pkg/util/resources"
+)
+
+//go:embed cloud-config
+var CloudConfig []byte
+
+type userDataValues struct {
+	OtelColScript string
+}
+
+const (
+	stackGaudi           = "icgaudi"
+	outputHost           = "icgHost"
+	outputUsername        = "icgUsername"
+	outputUserPrivateKey = "icgUserPrivatekey"
+
+	defaultProfile = "gx3d-160x1792x8gaudi3"
+	// RHEL AI stock image for Intel/x86_64 VPC instances (substring match via GetVPCImage)
+	// Resolves to e.g. ibm-redhat-ai-intel-1-5-1-amd64-1
+	defaultImage = "ibm-redhat-ai-intel"
+	defaultUser    = "cloud-user"
+)
+
+type GaudiArgs struct {
+	Prefix         string
+	SubnetID       string
+	OtelAppCode    string
+	OtelAuthToken  string
+	OtelEndpoint   string
+	OtelIndex      string
+	OtelExtraAttrs map[string]string
+}
+
+type gaudiRequest struct {
+	mCtx           *mc.Context
+	prefix         *string
+	zone           *string
+	subnetID       *string
+	otelAppCode    string
+	otelAuthToken  string
+	otelEndpoint   string
+	otelIndex      string
+	otelExtraAttrs map[string]string
+}
+
+func New(ctx *mc.ContextArgs, args *GaudiArgs) error {
+	ibmcloudProvider := ibmcloudp.Provider()
+	mCtx, err := mc.Init(ctx, ibmcloudProvider)
+	if err != nil {
+		return err
+	}
+
+	prefix := util.If(len(args.Prefix) > 0, args.Prefix, "main")
+
+	var zone *string
+	var subnetID *string
+	if args.SubnetID != "" {
+		s := strings.TrimSpace(args.SubnetID)
+		if s == "" {
+			return fmt.Errorf("--subnet-id must not be blank")
+		}
+		subnetID = &s
+	} else {
+		z, err := ibmcloudProvider.Zone()
+		if err != nil {
+			return err
+		}
+		zone = z
+	}
+
+	r := &gaudiRequest{
+		mCtx:           mCtx,
+		prefix:         &prefix,
+		zone:           zone,
+		subnetID:       subnetID,
+		otelAppCode:    args.OtelAppCode,
+		otelAuthToken:  args.OtelAuthToken,
+		otelEndpoint:   args.OtelEndpoint,
+		otelIndex:      args.OtelIndex,
+		otelExtraAttrs: args.OtelExtraAttrs,
+	}
+	cs := manager.Stack{
+		StackName:           mCtx.StackNameByProject(stackGaudi),
+		ProjectName:         mCtx.ProjectName(),
+		BackedURL:           mCtx.BackedURL(),
+		ProviderCredentials: ibmcloudp.DefaultCredentials,
+		DeployFunc:          r.deploy,
+	}
+	sr, err := manager.UpStack(r.mCtx, cs)
+	if err != nil {
+		return fmt.Errorf("stack creation failed: %w", err)
+	}
+	return manageResults(mCtx, sr, prefix)
+}
+
+func Destroy(mCtxArgs *mc.ContextArgs) (err error) {
+	mCtx, err := mc.Init(mCtxArgs, ibmcloudp.Provider())
+	if err != nil {
+		return err
+	}
+	if err := ibmcloudp.DestroyStack(mCtx, stackGaudi); err != nil {
+		return err
+	}
+	return ibmcloudp.CleanupState(mCtx)
+}
+
+func (r *gaudiRequest) deploy(ctx *pulumi.Context) error {
+	if r.subnetID != nil {
+		return r.deployWithExistingSubnet(ctx)
+	}
+	zone := *r.zone
+	rg, err := ibmcloud.NewResourceGroup(
+		ctx,
+		resourcesUtil.GetResourceName(*r.prefix, stackGaudi, "rg"),
+		&ibmcloud.ResourceGroupArgs{
+			Name: pulumi.String(r.mCtx.ProjectName()),
+		})
+	if err != nil {
+		return err
+	}
+	n, err := network.New(ctx,
+		&network.NetworkArgs{
+			Prefix:      *r.prefix,
+			Zone:        &zone,
+			RG:          rg,
+			ComponentID: stackGaudi,
+			Name:        fmt.Sprintf("%s-%s", *r.prefix, r.mCtx.ProjectName()),
+		})
+	if err != nil {
+		return err
+	}
+	pk, pik, err := isKey(ctx, r.mCtx, *r.prefix, stackGaudi, rg)
+	if err != nil {
+		return err
+	}
+	ctx.Export(fmt.Sprintf("%s-%s", *r.prefix, outputUserPrivateKey), pk.PrivateKeyPem)
+	imageId, err := icdata.GetVPCImage(&icdata.VPCImageArgs{
+		Name: defaultImage,
+		Arch: icdata.VPC_ARCH_X86_64,
+	})
+	if err != nil {
+		return err
+	}
+	instanceArgs := &ibmcloud.IsInstanceArgs{
+		Name:          pulumi.String(r.mCtx.ProjectName()),
+		Image:         pulumi.String(*imageId),
+		Profile:       pulumi.String(defaultProfile),
+		Vpc:           n.VPC.ID(),
+		Zone:          pulumi.String(zone),
+		ResourceGroup: rg.ID(),
+		Keys:          pulumi.StringArray{pik.ID()},
+		PrimaryNetworkInterface: &ibmcloud.IsInstancePrimaryNetworkInterfaceArgs{
+			Subnet: n.Subnet.ID(),
+			SecurityGroups: pulumi.StringArray{
+				n.SecurityGroup.ID(),
+			},
+		},
+	}
+	ud, err := gaudiUserData(r.otelArgs())
+	if err != nil {
+		return fmt.Errorf("failed to render user data: %w", err)
+	}
+	if ud != "" {
+		instanceArgs.UserData = pulumi.StringPtr(ud)
+	}
+	i, err := ibmcloud.NewIsInstance(ctx,
+		resourcesUtil.GetResourceName(*r.prefix, stackGaudi, "is"),
+		instanceArgs)
+	if err != nil {
+		return err
+	}
+	ctx.Export(fmt.Sprintf("%s-%s", *r.prefix, outputUsername), pulumi.String(defaultUser))
+	_, err = ibmcloud.NewIsInstanceNetworkInterfaceFloatingIp(ctx,
+		resourcesUtil.GetResourceName(*r.prefix, stackGaudi, "fipassoc"),
+		&ibmcloud.IsInstanceNetworkInterfaceFloatingIpArgs{
+			FloatingIp: n.Floatingip.ID(),
+			Instance:   i.ID(),
+			NetworkInterface: i.PrimaryNetworkInterface.ApplyT(
+				func(pni ibmcloud.IsInstancePrimaryNetworkInterface) string {
+					return *pni.Id
+				},
+			).(pulumi.StringOutput),
+		})
+	if err != nil {
+		return err
+	}
+	ctx.Export(fmt.Sprintf("%s-%s", *r.prefix, outputHost), n.Floatingip.Address)
+	_, err = remote.NewCommand(ctx,
+		resourcesUtil.GetResourceName(*r.prefix, stackGaudi, "readiness-cmd"),
+		&remote.CommandArgs{
+			Connection: remote.ConnectionArgs{
+				Host:           n.Floatingip.Address,
+				User:           pulumi.String(defaultUser),
+				PrivateKey:     pk.PrivateKeyOpenssh,
+				DialErrorLimit: pulumi.Int(-1),
+			},
+			Create: pulumi.String(command.CommandPing),
+			Update: pulumi.String(command.CommandPing),
+		}, pulumi.Timeouts(
+			&pulumi.CustomTimeouts{
+				Create: command.RemoteTimeout,
+				Update: command.RemoteTimeout}),
+		pulumi.DependsOn([]pulumi.Resource{i}))
+	return err
+}
+
+func (r *gaudiRequest) deployWithExistingSubnet(ctx *pulumi.Context) error {
+	subnetInfo, err := ibmcloud.LookupIsSubnet(ctx, &ibmcloud.LookupIsSubnetArgs{
+		Identifier: r.subnetID,
+	})
+	if err != nil {
+		return err
+	}
+	name := fmt.Sprintf("%s-%s", *r.prefix, r.mCtx.ProjectName())
+	sg, err := network.NewSecurityGroupWithSSH(ctx, &network.SecurityGroupArgs{
+		Prefix:      *r.prefix,
+		ComponentID: stackGaudi,
+		Name:        name,
+		VPC:         pulumi.String(subnetInfo.Vpc),
+	})
+	if err != nil {
+		return err
+	}
+	fip, err := network.NewFloatingIP(ctx, &network.FloatingIPArgs{
+		Prefix:      *r.prefix,
+		ComponentID: stackGaudi,
+		Name:        name,
+		Zone:        pulumi.String(subnetInfo.Zone),
+	})
+	if err != nil {
+		return err
+	}
+	pk, pik, err := isKey(ctx, r.mCtx, *r.prefix, stackGaudi, nil)
+	if err != nil {
+		return err
+	}
+	ctx.Export(fmt.Sprintf("%s-%s", *r.prefix, outputUserPrivateKey), pk.PrivateKeyPem)
+	imageId, err := icdata.GetVPCImage(&icdata.VPCImageArgs{
+		Name: defaultImage,
+		Arch: icdata.VPC_ARCH_X86_64,
+	})
+	if err != nil {
+		return err
+	}
+	instanceArgs := &ibmcloud.IsInstanceArgs{
+		Name:    pulumi.String(r.mCtx.ProjectName()),
+		Image:   pulumi.String(*imageId),
+		Profile: pulumi.String(defaultProfile),
+		Vpc:     pulumi.String(subnetInfo.Vpc),
+		Zone:    pulumi.String(subnetInfo.Zone),
+		Keys:    pulumi.StringArray{pik.ID()},
+		PrimaryNetworkInterface: &ibmcloud.IsInstancePrimaryNetworkInterfaceArgs{
+			Subnet:         pulumi.String(*r.subnetID),
+			SecurityGroups: pulumi.StringArray{sg.ID()},
+		},
+	}
+	ud, err := gaudiUserData(r.otelArgs())
+	if err != nil {
+		return fmt.Errorf("failed to render user data: %w", err)
+	}
+	if ud != "" {
+		instanceArgs.UserData = pulumi.StringPtr(ud)
+	}
+	i, err := ibmcloud.NewIsInstance(ctx,
+		resourcesUtil.GetResourceName(*r.prefix, stackGaudi, "is"),
+		instanceArgs)
+	if err != nil {
+		return err
+	}
+	ctx.Export(fmt.Sprintf("%s-%s", *r.prefix, outputUsername), pulumi.String(defaultUser))
+	_, err = ibmcloud.NewIsInstanceNetworkInterfaceFloatingIp(ctx,
+		resourcesUtil.GetResourceName(*r.prefix, stackGaudi, "fipassoc"),
+		&ibmcloud.IsInstanceNetworkInterfaceFloatingIpArgs{
+			FloatingIp: fip.ID(),
+			Instance:   i.ID(),
+			NetworkInterface: i.PrimaryNetworkInterface.ApplyT(
+				func(pni ibmcloud.IsInstancePrimaryNetworkInterface) string {
+					return *pni.Id
+				},
+			).(pulumi.StringOutput),
+		})
+	if err != nil {
+		return err
+	}
+	ctx.Export(fmt.Sprintf("%s-%s", *r.prefix, outputHost), fip.Address)
+	_, err = remote.NewCommand(ctx,
+		resourcesUtil.GetResourceName(*r.prefix, stackGaudi, "readiness-cmd"),
+		&remote.CommandArgs{
+			Connection: remote.ConnectionArgs{
+				Host:           fip.Address,
+				User:           pulumi.String(defaultUser),
+				PrivateKey:     pk.PrivateKeyOpenssh,
+				DialErrorLimit: pulumi.Int(-1),
+			},
+			Create: pulumi.String(command.CommandPing),
+			Update: pulumi.String(command.CommandPing),
+		}, pulumi.Timeouts(
+			&pulumi.CustomTimeouts{
+				Create: command.RemoteTimeout,
+				Update: command.RemoteTimeout}),
+		pulumi.DependsOn([]pulumi.Resource{i}))
+	return err
+}
+
+func (r *gaudiRequest) otelArgs() *otelcol.OtelcolArgs {
+	if r.otelAppCode == "" || r.otelAuthToken == "" || r.otelIndex == "" {
+		return nil
+	}
+	return &otelcol.OtelcolArgs{
+		AppCode:    r.otelAppCode,
+		AuthToken:  r.otelAuthToken,
+		Index:      r.otelIndex,
+		Endpoint:   r.otelEndpoint,
+		Arch:       otelcol.Amd64,
+		SyslogPath: "/var/log/messages",
+		SecurePath: "/var/log/secure",
+		ExtraAttrs: r.otelExtraAttrs,
+	}
+}
+
+func gaudiUserData(otelArgs *otelcol.OtelcolArgs) (string, error) {
+	otelScript := ""
+	if otelArgs != nil {
+		s, err := otelcol.GetSnippetAsCloudInitWritableFile(otelArgs)
+		if err != nil {
+			return "", err
+		}
+		otelScript = *s
+	}
+	script, err := file.Template(
+		userDataValues{
+			OtelColScript: otelScript,
+		},
+		string(CloudConfig))
+	if err != nil {
+		return "", err
+	}
+	const boundary = "MAPT-CLOUD-CONFIG"
+	encoded := base64.StdEncoding.EncodeToString([]byte(script))
+	return strings.Join([]string{
+		"MIME-Version: 1.0",
+		`Content-Type: multipart/mixed; boundary="` + boundary + `"`,
+		"",
+		"--" + boundary,
+		`Content-Type: text/cloud-config; charset="us-ascii"`,
+		"Content-Transfer-Encoding: base64",
+		"",
+		encoded,
+		"--" + boundary + "--",
+		"",
+	}, "\n"), nil
+}
+
+func manageResults(mCtx *mc.Context, stackResult auto.UpResult, prefix string) error {
+	return output.Write(stackResult, mCtx.GetResultsOutputPath(), map[string]string{
+		fmt.Sprintf("%s-%s", prefix, outputUsername):        "username",
+		fmt.Sprintf("%s-%s", prefix, outputUserPrivateKey):  "id_rsa",
+		fmt.Sprintf("%s-%s", prefix, outputHost):            "host",
+	})
+}
+
+func isKey(ctx *pulumi.Context, mCtx *mc.Context, prefix, cId string, rg *ibmcloud.ResourceGroup) (*tls.PrivateKey, *ibmcloud.IsSshKey, error) {
+	pk, err := tls.NewPrivateKey(
+		ctx,
+		resourcesUtil.GetResourceName(prefix, cId, "pk"),
+		&tls.PrivateKeyArgs{
+			Algorithm: pulumi.String("RSA"),
+			RsaBits:   pulumi.Int(4096),
+		})
+	if err != nil {
+		return nil, nil, err
+	}
+	if mCtx.Debug() {
+		pk.PublicKeyOpenssh.ApplyT(
+			func(publicKey string) error {
+				logging.Debugf("public key: %s", publicKey)
+				return nil
+			})
+	}
+	sshKeyArgs := &ibmcloud.IsSshKeyArgs{
+		Name:      pulumi.String(mCtx.ProjectName()),
+		PublicKey: pk.PublicKeyOpenssh,
+	}
+	if rg != nil {
+		sshKeyArgs.ResourceGroup = rg.ID()
+	}
+	pik, err := ibmcloud.NewIsSshKey(ctx,
+		resourcesUtil.GetResourceName(prefix, cId, "pik"),
+		sshKeyArgs)
+	return pk, pik, err
+}


### PR DESCRIPTION
## Summary

Adds `ibmcloud ibm-gaudi` create/destroy commands for provisioning Intel Gaudi 3 accelerator instances on IBM Cloud VPC.

- New target `ibm-gaudi` with auto-provisioning via RHEL AI image on `gx3d-160x1792x8` profile (us-south-2)
- SSH readiness check with retry loop before returning connection details
- Uses `cloud-user` as default SSH user for the RHEL AI image
- Full VPC networking stack (VPC, subnet, security group, floating IP, public gateway)
- Supports IBM COS S3-compatible backend for Pulumi state

Resolves: AIPCC-15489