### PR TITLE
feat(aws): add RHAIIS auto-start and expose-ports flags for RHEL AI provisioning

### DIFF
--- a/cmd/mapt/cmd/aws/hosts/rhelai.go
+++ b/cmd/mapt/cmd/aws/hosts/rhelai.go
@@ -72,6 +72,7 @@ func getRHELAICreate() *cobra.Command {
 					HFToken:          viper.GetString(params.RhelAIHFToken),
 					APIKey:           viper.GetString(params.RhelAIAPIKey),
 					AutoStart:        viper.IsSet(params.RhelAIAutoStart),
+					ExposePorts:      viper.GetIntSlice(params.RhelAIExposePorts),
 				})
 		},
 	}
@@ -85,6 +86,7 @@ func getRHELAICreate() *cobra.Command {
 	flagSet.StringP(params.RhelAIHFToken, "", "", params.RhelAIHFTokenDesc)
 	flagSet.StringP(params.RhelAIAPIKey, "", "", params.RhelAIAPIKeyDesc)
 	flagSet.Bool(params.RhelAIAutoStart, false, params.RhelAIAutoStartDesc)
+	flagSet.IntSlice(params.RhelAIExposePorts, nil, params.RhelAIExposePortsDesc)
 	flagSet.StringP(params.Timeout, "", "", params.TimeoutDesc)
 	params.AddComputeRequestFlags(flagSet)
 	params.AddSpotFlags(flagSet)

--- a/cmd/mapt/cmd/aws/hosts/rhelai.go
+++ b/cmd/mapt/cmd/aws/hosts/rhelai.go
@@ -68,6 +68,10 @@ func getRHELAICreate() *cobra.Command {
 					Spot:             params.SpotArgs(),
 					Timeout:          viper.GetString(params.Timeout),
 					ServiceEndpoints: params.NetworkServiceEndpoints(),
+					Model:            viper.GetString(params.RhelAIModel),
+					HFToken:          viper.GetString(params.RhelAIHFToken),
+					APIKey:           viper.GetString(params.RhelAIAPIKey),
+					AutoStart:        viper.IsSet(params.RhelAIAutoStart),
 				})
 		},
 	}
@@ -77,6 +81,10 @@ func getRHELAICreate() *cobra.Command {
 	flagSet.StringP(params.RhelAIVersion, "", params.RhelAIVersionDefault, params.RhelAIVersionDesc)
 	flagSet.StringP(params.RhelAIAccelerator, "", params.RhelAIAccelearatorDefault, params.RhelAIAccelearatorDesc)
 	flagSet.StringP(params.RhelAICustomImage, "", "", params.RhelAICustomImageDesc)
+	flagSet.StringP(params.RhelAIModel, "", "", params.RhelAIModelDesc)
+	flagSet.StringP(params.RhelAIHFToken, "", "", params.RhelAIHFTokenDesc)
+	flagSet.StringP(params.RhelAIAPIKey, "", "", params.RhelAIAPIKeyDesc)
+	flagSet.Bool(params.RhelAIAutoStart, false, params.RhelAIAutoStartDesc)
 	flagSet.StringP(params.Timeout, "", "", params.TimeoutDesc)
 	params.AddComputeRequestFlags(flagSet)
 	params.AddSpotFlags(flagSet)

--- a/cmd/mapt/cmd/params/params.go
+++ b/cmd/mapt/cmd/params/params.go
@@ -121,6 +121,14 @@ const (
 	RhelAICustomImageDesc     string = "custom image name to spin RHEL AI OS (AMI name for AWS, image name for Azure)"
 	RhelAIMarketplace         string = "marketplace"
 	RhelAIMarketplaceDesc     string = "use the cloud provider's marketplace RHEL AI image instead of a shared gallery or custom image"
+	RhelAIModel               string = "model"
+	RhelAIModelDesc           string = "Hugging Face model ID for RHAIIS (e.g. meta-llama/Llama-3.2-1B-Instruct)"
+	RhelAIHFToken             string = "hf-token"
+	RhelAIHFTokenDesc         string = "Hugging Face Hub token for model download"
+	RhelAIAPIKey              string = "api-key"
+	RhelAIAPIKeyDesc          string = "API key to enforce secure connections to vLLM"
+	RhelAIAutoStart           string = "auto-start"
+	RhelAIAutoStartDesc       string = "automatically configure and start RHAIIS after provisioning"
 
 	// Serverless
 	Timeout        string = "timeout"

--- a/cmd/mapt/cmd/params/params.go
+++ b/cmd/mapt/cmd/params/params.go
@@ -129,6 +129,8 @@ const (
 	RhelAIAPIKeyDesc          string = "API key to enforce secure connections to vLLM"
 	RhelAIAutoStart           string = "auto-start"
 	RhelAIAutoStartDesc       string = "automatically configure and start RHAIIS after provisioning"
+	RhelAIExposePorts         string = "expose-ports"
+	RhelAIExposePortsDesc     string = "comma-separated list of ports to expose through the load balancer and security group (e.g. 8000,8080)"
 
 	// Serverless
 	Timeout        string = "timeout"

--- a/pkg/provider/aws/action/rhel-ai/rhelai.go
+++ b/pkg/provider/aws/action/rhel-ai/rhelai.go
@@ -42,6 +42,10 @@ type rhelAIRequest struct {
 	serviceEndpoints []string
 	allocationData   *allocation.AllocationResult
 	diskSize         *int
+	model            *string
+	hfToken          *string
+	apiKey           *string
+	autoStart        bool
 }
 
 func (r *rhelAIRequest) validate() error {
@@ -75,7 +79,11 @@ func Create(mCtxArgs *mc.ContextArgs, args *apiRHELAI.RHELAIArgs) (err error) {
 		arch:             &args.Arch,
 		timeout:          &args.Timeout,
 		serviceEndpoints: args.ServiceEndpoints,
-		diskSize:         args.ComputeRequest.DiskSize}
+		diskSize:         args.ComputeRequest.DiskSize,
+		model:            &args.Model,
+		hfToken:          &args.HFToken,
+		apiKey:           &args.APIKey,
+		autoStart:        args.AutoStart}
 	if args.Spot != nil {
 		r.spot = args.Spot.Spot
 	}
@@ -277,8 +285,26 @@ func (r *rhelAIRequest) deploy(ctx *pulumi.Context) error {
 			return err
 		}
 	}
-	return c.Readiness(ctx, command.CommandPing, *r.prefix, awsRHELDedicatedID,
-		keyResources.PrivateKey, amiUserDefault, nil, c.Dependencies)
+	if !r.autoStart {
+		return c.Readiness(ctx, command.CommandPing, *r.prefix, awsRHELDedicatedID,
+			keyResources.PrivateKey, amiUserDefault, nil, c.Dependencies)
+	}
+	readinessCmd, err := c.RunCommand(ctx,
+		command.CommandPing,
+		compute.LoggingCmdStd,
+		fmt.Sprintf("%s-readiness", *r.prefix), awsRHELDedicatedID,
+		keyResources.PrivateKey, amiUserDefault,
+		nil, c.Dependencies)
+	if err != nil {
+		return err
+	}
+	_, err = c.RunCommand(ctx,
+		r.rhaiisSetupScript(),
+		compute.NoLoggingCmdStd,
+		fmt.Sprintf("%s-rhaiis-setup", *r.prefix), awsRHELDedicatedID,
+		keyResources.PrivateKey, amiUserDefault,
+		nil, []pulumi.Resource{readinessCmd})
+	return err
 }
 
 // Write exported values in context to files o a selected target folder
@@ -314,6 +340,30 @@ func (r *rhelAIRequest) securityGroups(ctx *pulumi.Context, mCtx *mc.Context,
 			return sg.ID()
 		})
 	return pulumi.StringArray(sgs[:]), nil
+}
+
+func (r *rhelAIRequest) rhaiisSetupScript() string {
+	confDir := "/etc/containers/systemd/rhaiis.container.d"
+	script := fmt.Sprintf(
+		"sudo cp %s/install.conf.example %s/install.conf",
+		confDir, confDir)
+	if len(*r.hfToken) > 0 {
+		script += fmt.Sprintf(
+			" && sudo sed -i 's|HUGGING_FACE_HUB_TOKEN=.*|HUGGING_FACE_HUB_TOKEN=%s|' %s/install.conf",
+			*r.hfToken, confDir)
+	}
+	if len(*r.model) > 0 {
+		script += fmt.Sprintf(
+			` && sudo sed -i 's|--model .*|--model %s \\|' %s/install.conf`,
+			*r.model, confDir)
+	}
+	if len(*r.apiKey) > 0 {
+		script += fmt.Sprintf(
+			" && sudo sed -i '/\\[Install\\]/i Environment=VLLM_API_KEY=%s' %s/install.conf",
+			*r.apiKey, confDir)
+	}
+	script += " && sudo systemctl daemon-reload && sudo systemctl start rhaiis"
+	return script
 }
 
 func checkAMIExists(ctx context.Context, amiName, region, arch *string) error {

--- a/pkg/provider/aws/action/rhel-ai/rhelai.go
+++ b/pkg/provider/aws/action/rhel-ai/rhelai.go
@@ -46,6 +46,7 @@ type rhelAIRequest struct {
 	hfToken          *string
 	apiKey           *string
 	autoStart        bool
+	exposePorts      []int
 }
 
 func (r *rhelAIRequest) validate() error {
@@ -83,7 +84,8 @@ func Create(mCtxArgs *mc.ContextArgs, args *apiRHELAI.RHELAIArgs) (err error) {
 		model:            &args.Model,
 		hfToken:          &args.HFToken,
 		apiKey:           &args.APIKey,
-		autoStart:        args.AutoStart}
+		autoStart:        args.AutoStart,
+		exposePorts:      args.ExposePorts}
 	if args.Spot != nil {
 		r.spot = args.Spot.Spot
 	}
@@ -260,7 +262,7 @@ func (r *rhelAIRequest) deploy(ctx *pulumi.Context) error {
 		DiskSize:       &effectiveDiskSize,
 		LB:             nw.LoadBalancer,
 		Eip:            nw.Eip,
-		LBTargetGroups: []int{22}}
+		LBTargetGroups: r.lbTargetGroups()}
 	if r.allocationData.SpotPrice != nil {
 		cr.Spot = true
 		cr.SpotPrice = *r.allocationData.SpotPrice
@@ -323,13 +325,23 @@ func (r *rhelAIRequest) securityGroups(ctx *pulumi.Context, mCtx *mc.Context,
 	// ingress for ssh access from 0.0.0.0
 	sshIngressRule := securityGroup.SSH_TCP
 	sshIngressRule.CidrBlocks = infra.NETWORKING_CIDR_ANY_IPV4
+	ingressRules := []securityGroup.IngressRules{sshIngressRule}
+	for _, port := range r.exposePorts {
+		rule := securityGroup.IngressRules{
+			Description: fmt.Sprintf("port-%d", port),
+			FromPort:    port,
+			ToPort:      port,
+			Protocol:    "tcp",
+			CidrBlocks:  infra.NETWORKING_CIDR_ANY_IPV4,
+		}
+		ingressRules = append(ingressRules, rule)
+	}
 	// Create SG with ingress rules
 	sg, err := securityGroup.SGRequest{
 		Name:        resourcesUtil.GetResourceName(*r.prefix, awsRHELDedicatedID, "sg"),
 		VPC:         vpc,
 		Description: fmt.Sprintf("sg for %s", awsRHELDedicatedID),
-		IngressRules: []securityGroup.IngressRules{
-			sshIngressRule},
+		IngressRules: ingressRules,
 	}.Create(ctx, mCtx)
 	if err != nil {
 		return nil, err
@@ -340,6 +352,10 @@ func (r *rhelAIRequest) securityGroups(ctx *pulumi.Context, mCtx *mc.Context,
 			return sg.ID()
 		})
 	return pulumi.StringArray(sgs[:]), nil
+}
+
+func (r *rhelAIRequest) lbTargetGroups() []int {
+	return append([]int{22}, r.exposePorts...)
 }
 
 func (r *rhelAIRequest) rhaiisSetupScript() string {

--- a/pkg/target/host/rhelai/api.go
+++ b/pkg/target/host/rhelai/api.go
@@ -6,15 +6,19 @@ import (
 )
 
 type RHELAIArgs struct {
-	Prefix         string
-	Accelerator    string
-	Version        string
-	CustomImage    string
-	Marketplace    bool
-	Arch           string
-	ComputeRequest *cr.ComputeRequestArgs
-	Spot           *spotTypes.SpotArgs
-	ServiceEndpoints      []string
+	Prefix           string
+	Accelerator      string
+	Version          string
+	CustomImage      string
+	Marketplace      bool
+	Arch             string
+	ComputeRequest   *cr.ComputeRequestArgs
+	Spot             *spotTypes.SpotArgs
+	ServiceEndpoints []string
 	// If timeout is set a severless scheduled task will be created to self destroy the resources
-	Timeout string
+	Timeout   string
+	Model     string
+	HFToken   string
+	APIKey    string
+	AutoStart bool
 }

--- a/pkg/target/host/rhelai/api.go
+++ b/pkg/target/host/rhelai/api.go
@@ -19,6 +19,7 @@ type RHELAIArgs struct {
 	Timeout   string
 	Model     string
 	HFToken   string
-	APIKey    string
-	AutoStart bool
+	APIKey      string
+	AutoStart   bool
+	ExposePorts []int
 }

--- a/tkn/infra-aws-rhel-ai.yaml
+++ b/tkn/infra-aws-rhel-ai.yaml
@@ -140,7 +140,22 @@ spec:
     - name: version
       description: Version of RHEL AI OS (default 3.0.0)
       default: "3.0.0"
-    
+    - name: auto-start
+      description: Automatically configure and start RHAIIS (vLLM) after provisioning.
+      default: "false"
+    - name: model
+      description: HuggingFace model ID for RHAIIS (e.g. meta-llama/Llama-3.2-1B-Instruct)
+      default: ""
+    - name: hf-token
+      description: HuggingFace Hub token for model download. Read from secret if not set directly.
+      default: ""
+    - name: api-key
+      description: API key to enforce secure connections to vLLM.
+      default: ""
+    - name: expose-ports
+      description: Comma-separated list of ports to expose through the load balancer and security group (e.g. 8000,8080).
+      default: ""
+
     # Network params
     - name: service-endpoints
       description: |
@@ -286,6 +301,21 @@ spec:
           fi
           if [[ "$(params.service-endpoints)" != "" ]]; then
             cmd+="--service-endpoints '$(params.service-endpoints)' "
+          fi
+          if [[ "$(params.auto-start)" == "true" ]]; then
+            cmd+="--auto-start "
+          fi
+          if [[ "$(params.model)" != "" ]]; then
+            cmd+="--model '$(params.model)' "
+          fi
+          if [[ "$(params.hf-token)" != "" ]]; then
+            cmd+="--hf-token '$(params.hf-token)' "
+          fi
+          if [[ "$(params.api-key)" != "" ]]; then
+            cmd+="--api-key '$(params.api-key)' "
+          fi
+          if [[ "$(params.expose-ports)" != "" ]]; then
+            cmd+="--expose-ports '$(params.expose-ports)' "
           fi
           cmd+="--tags '$(params.tags)' "
         fi

--- a/tkn/template/infra-aws-rhel-ai.yaml
+++ b/tkn/template/infra-aws-rhel-ai.yaml
@@ -140,7 +140,22 @@ spec:
     - name: version
       description: Version of RHEL AI OS (default 3.0.0)
       default: "3.0.0"
-    
+    - name: auto-start
+      description: Automatically configure and start RHAIIS (vLLM) after provisioning.
+      default: "false"
+    - name: model
+      description: HuggingFace model ID for RHAIIS (e.g. meta-llama/Llama-3.2-1B-Instruct)
+      default: ""
+    - name: hf-token
+      description: HuggingFace Hub token for model download. Read from secret if not set directly.
+      default: ""
+    - name: api-key
+      description: API key to enforce secure connections to vLLM.
+      default: ""
+    - name: expose-ports
+      description: Comma-separated list of ports to expose through the load balancer and security group (e.g. 8000,8080).
+      default: ""
+
     # Network params
     - name: service-endpoints
       description: |
@@ -286,6 +301,21 @@ spec:
           fi
           if [[ "$(params.service-endpoints)" != "" ]]; then
             cmd+="--service-endpoints '$(params.service-endpoints)' "
+          fi
+          if [[ "$(params.auto-start)" == "true" ]]; then
+            cmd+="--auto-start "
+          fi
+          if [[ "$(params.model)" != "" ]]; then
+            cmd+="--model '$(params.model)' "
+          fi
+          if [[ "$(params.hf-token)" != "" ]]; then
+            cmd+="--hf-token '$(params.hf-token)' "
+          fi
+          if [[ "$(params.api-key)" != "" ]]; then
+            cmd+="--api-key '$(params.api-key)' "
+          fi
+          if [[ "$(params.expose-ports)" != "" ]]; then
+            cmd+="--expose-ports '$(params.expose-ports)' "
           fi
           cmd+="--tags '$(params.tags)' "
         fi


### PR DESCRIPTION
## Summary

Add `--auto-start`, `--model`, `--hf-token`, `--api-key`, and `--expose-ports` flags to `mapt aws rhel-ai create` to configure and start the RHAIIS inference server automatically after VM provisioning, and expose additional ports through the load balancer and security group.

Closes https://github.com/redhat-developer/mapt/issues/759

### Auto-start flags

After `mapt aws rhel-ai create` provisions a VM, the RHEL AI image ships with RHAIIS (vLLM inference server) pre-installed as a systemd quadlet but **inactive**. Users currently must SSH in manually to configure and start it. These flags automate that post-provisioning step.

When `--auto-start` is set, mapt SSHes into the provisioned VM after readiness, configures the RHAIIS quadlet with the provided model and credentials, and starts the systemd service. Sensitive output (HF token) is suppressed from logs using `NoLoggingCmdStd`. Without `--auto-start`, behavior is unchanged.

### Expose ports

`--expose-ports` accepts a comma-separated list of ports (e.g. `8000,8080`) to expose through the AWS load balancer target groups and security group ingress rules. By default only port 22 (SSH) is exposed. This enables external access to services like vLLM (port 8000) without requiring SSH tunneling.

### Tekton task template

Updated `tkn/template/infra-aws-rhel-ai.yaml` with all new params: `auto-start`, `model`, `hf-token`, `api-key`, and `expose-ports`.

**Usage:**

```bash
mapt aws rhel-ai create \
    --project-name test \
    --backed-url "file:///tmp/test" \
    --version 3.4.0-ea.1 \
    --spot \
    --auto-start \
    --model meta-llama/Llama-3.2-1B-Instruct \
    --hf-token $HF_TOKEN \
    --api-key $API_KEY \
    --expose-ports 8000
```

**Validated end-to-end:** provisioned RHEL AI VM with `--auto-start` and `--expose-ports 8000`, confirmed `systemctl status rhaiis` active, `curl <host>:8000/v1/models` returns the model externally, and chat completions respond successfully.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>