### PR TITLE
fix(azure): make location optional for spot allocation

### DIFF
--- a/pkg/provider/azure/action/aks/aks.go
+++ b/pkg/provider/azure/action/aks/aks.go
@@ -59,7 +59,11 @@ func (r *aksRequest) validate() error {
 func Create(mCtxArgs *mc.ContextArgs, args *AKSArgs) (err error) {
 	logging.Debug("Creating AKS")
 	// Create mapt Context
-	mCtx, err := mc.Init(mCtxArgs, azure.Provider())
+	provider := azure.Provider()
+	if args.Spot != nil && args.Spot.Spot {
+		provider = azure.ProviderOptionalLocation()
+	}
+	mCtx, err := mc.Init(mCtxArgs, provider)
 	if err != nil {
 		return err
 	}
@@ -87,7 +91,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *AKSArgs) (err error) {
 
 func Destroy(mCtxArgs *mc.ContextArgs) error {
 	logging.Debug("Destroy AKS")
-	mCtx, err := mc.Init(mCtxArgs, azure.Provider())
+	mCtx, err := mc.Init(mCtxArgs, azure.ProviderOptionalLocation())
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/azure/action/kind/kind.go
+++ b/pkg/provider/azure/action/kind/kind.go
@@ -46,7 +46,11 @@ func (r *kindRequest) validate() error {
 
 func Create(mCtxArgs *mc.ContextArgs, args *utilKind.KindArgs) (*utilKind.KindResults, error) {
 	// Create mapt Context
-	mCtx, err := mc.Init(mCtxArgs, azure.Provider())
+	provider := azure.Provider()
+	if args.Spot != nil && args.Spot.Spot {
+		provider = azure.ProviderOptionalLocation()
+	}
+	mCtx, err := mc.Init(mCtxArgs, provider)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +101,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *utilKind.KindArgs) (*utilKind.KindRe
 }
 
 func Destroy(mCtxArgs *mc.ContextArgs) (err error) {
-	mCtx, err := mc.Init(mCtxArgs, azure.Provider())
+	mCtx, err := mc.Init(mCtxArgs, azure.ProviderOptionalLocation())
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/azure/action/linux/linux.go
+++ b/pkg/provider/azure/action/linux/linux.go
@@ -78,7 +78,11 @@ func (r *linuxRequest) validate() error {
 
 func Create(mCtxArgs *mc.ContextArgs, args *LinuxArgs) (err error) {
 	// Create mapt Context
-	mCtx, err := mc.Init(mCtxArgs, azure.Provider())
+	provider := azure.Provider()
+	if args.Spot != nil && args.Spot.Spot {
+		provider = azure.ProviderOptionalLocation()
+	}
+	mCtx, err := mc.Init(mCtxArgs, provider)
 	if err != nil {
 		return err
 	}
@@ -126,7 +130,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *LinuxArgs) (err error) {
 }
 
 func Destroy(mCtxArgs *mc.ContextArgs) error {
-	mCtx, err := mc.Init(mCtxArgs, azure.Provider())
+	mCtx, err := mc.Init(mCtxArgs, azure.ProviderOptionalLocation())
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/azure/action/windows/windows.go
+++ b/pkg/provider/azure/action/windows/windows.go
@@ -82,7 +82,11 @@ type ghActionsRunnerData struct {
 
 func Create(mCtxArgs *mc.ContextArgs, args *WindowsArgs) (err error) {
 	// Create mapt Context
-	mCtx, err := mc.Init(mCtxArgs, azure.Provider())
+	provider := azure.Provider()
+	if args.Spot != nil && args.Spot.Spot {
+		provider = azure.ProviderOptionalLocation()
+	}
+	mCtx, err := mc.Init(mCtxArgs, provider)
 	if err != nil {
 		return err
 	}
@@ -120,7 +124,7 @@ func Create(mCtxArgs *mc.ContextArgs, args *WindowsArgs) (err error) {
 }
 
 func Destroy(mCtxArgs *mc.ContextArgs) error {
-	mCtx, err := mc.Init(mCtxArgs, azure.Provider())
+	mCtx, err := mc.Init(mCtxArgs, azure.ProviderOptionalLocation())
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/azure/azure.go
+++ b/pkg/provider/azure/azure.go
@@ -22,10 +22,16 @@ var azIdentityEnvs = []string{
 	"AZURE_CLIENT_SECRET",
 }
 
-type Azure struct{}
+type Azure struct {
+	locationOptional bool
+}
 
 func Provider() *Azure {
 	return &Azure{}
+}
+
+func ProviderOptionalLocation() *Azure {
+	return &Azure{locationOptional: true}
 }
 
 func (a *Azure) Init(ctx context.Context, backedURL string) (string, error) {
@@ -34,6 +40,9 @@ func (a *Azure) Init(ctx context.Context, backedURL string) (string, error) {
 }
 
 func (a *Azure) DefaultHostingPlace() (*string, error) {
+	if a.locationOptional {
+		return nil, nil
+	}
 	hp := os.Getenv("ARM_LOCATION_NAME")
 	if len(hp) > 0 {
 		return &hp, nil


### PR DESCRIPTION
Azure spot allocation finds its own location, so there's no reason to require one at init time. A fix in #826 (commit 7c5d50d) changed `DefaultHostingPlace()` to hard-error when no location env var is set — that worked fine for on-demand but also fired for spot, breaking workflows that never needed it (see #839).

This restores the original `nil, nil` return with an info log. The non-spot path in `allocation.go` already enforces location when it actually matters.

Fixes #839.

Co-Authored-By: Claude <Sonnet 4.6> <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>