### PR TITLE
fix(aws/azure) : sanitize newlines from host/username in AWS and Azure secrets

### DIFF
--- a/pkg/tkn/host_access_secret_test.go
+++ b/pkg/tkn/host_access_secret_test.go
@@ -1,0 +1,72 @@
+package tkn
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAWSHostAccessSecretEncoding(t *testing.T) {
+	root := moduleRoot(t)
+
+	for _, dir := range []string{"tkn", filepath.Join("tkn", "template")} {
+		entries, err := os.ReadDir(filepath.Join(root, dir))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if !strings.HasPrefix(name, "infra-aws-") || !strings.HasSuffix(name, ".yaml") {
+				continue
+			}
+			checkFile(t, filepath.Join(root, dir, name))
+		}
+	}
+}
+
+func checkFile(t *testing.T, path string) {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.Contains(line, "$(cat /opt/host-info/") {
+			continue
+		}
+		if strings.Contains(line, "id_rsa:") {
+			if strings.Contains(line, "tr -d") {
+				t.Errorf("%s: id_rsa must not use tr -d: %s", path, strings.TrimSpace(line))
+			}
+			continue
+		}
+		if !strings.Contains(line, `tr -d '\n\r'`) {
+			t.Errorf("%s: host/username must use tr -d: %s", path, strings.TrimSpace(line))
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, _ := os.Getwd()
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found")
+		}
+		dir = parent
+	}
+}

--- a/pkg/tkn/host_access_secret_test.go
+++ b/pkg/tkn/host_access_secret_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestAWSHostAccessSecretEncoding(t *testing.T) {
+func TestHostAccessSecretEncoding(t *testing.T) {
 	root := moduleRoot(t)
 
 	for _, dir := range []string{"tkn", filepath.Join("tkn", "template")} {
@@ -18,7 +18,7 @@ func TestAWSHostAccessSecretEncoding(t *testing.T) {
 		}
 		for _, entry := range entries {
 			name := entry.Name()
-			if !strings.HasPrefix(name, "infra-aws-") || !strings.HasSuffix(name, ".yaml") {
+			if !isInfraTask(name) {
 				continue
 			}
 			checkFile(t, filepath.Join(root, dir, name))
@@ -26,14 +26,37 @@ func TestAWSHostAccessSecretEncoding(t *testing.T) {
 	}
 }
 
+func isInfraTask(name string) bool {
+	return strings.HasSuffix(name, ".yaml") &&
+		(strings.HasPrefix(name, "infra-aws-") || strings.HasPrefix(name, "infra-azure-"))
+}
+
 func checkFile(t *testing.T, path string) {
 	t.Helper()
+
+	sanitizeFields := map[string]struct{}{
+		"host":             {},
+		"username":         {},
+		"bastion-host":     {},
+		"bastion-username": {},
+		"adminusername":    {},
+	}
+	preserveFields := map[string]struct{}{
+		"id_rsa":            {},
+		"bastion-id_rsa":    {},
+		"userpassword":      {},
+		"adminuserpassword": {},
+	}
 
 	f, err := os.Open(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
@@ -41,19 +64,32 @@ func checkFile(t *testing.T, path string) {
 		if !strings.Contains(line, "$(cat /opt/host-info/") {
 			continue
 		}
-		if strings.Contains(line, "id_rsa:") {
+		field, ok := hostInfoField(line)
+		if !ok {
+			continue
+		}
+		if _, ok := preserveFields[field]; ok {
 			if strings.Contains(line, "tr -d") {
-				t.Errorf("%s: id_rsa must not use tr -d: %s", path, strings.TrimSpace(line))
+				t.Errorf("%s: %s must not use tr -d: %s", path, field, strings.TrimSpace(line))
 			}
 			continue
 		}
-		if !strings.Contains(line, `tr -d '\n\r'`) {
-			t.Errorf("%s: host/username must use tr -d: %s", path, strings.TrimSpace(line))
+		if _, ok := sanitizeFields[field]; ok && !strings.Contains(line, `tr -d '\n\r'`) {
+			t.Errorf("%s: %s must use tr -d: %s", path, field, strings.TrimSpace(line))
 		}
 	}
 	if err := sc.Err(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func hostInfoField(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	field, _, ok := strings.Cut(line, ":")
+	if !ok {
+		return "", false
+	}
+	return field, true
 }
 
 func moduleRoot(t *testing.T) string {

--- a/tkn/infra-aws-fedora.yaml
+++ b/tkn/infra-aws-fedora.yaml
@@ -342,14 +342,14 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
           bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi

--- a/tkn/infra-aws-mac.yaml
+++ b/tkn/infra-aws-mac.yaml
@@ -294,14 +294,14 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
           bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi

--- a/tkn/infra-aws-rhel-ai.yaml
+++ b/tkn/infra-aws-rhel-ai.yaml
@@ -350,8 +350,8 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 

--- a/tkn/infra-aws-rhel.yaml
+++ b/tkn/infra-aws-rhel.yaml
@@ -368,14 +368,14 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
           bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi

--- a/tkn/infra-aws-windows-server.yaml
+++ b/tkn/infra-aws-windows-server.yaml
@@ -301,14 +301,14 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
           bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi

--- a/tkn/infra-azure-fedora.yaml
+++ b/tkn/infra-azure-fedora.yaml
@@ -297,8 +297,8 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 

--- a/tkn/infra-azure-rhel-ai.yaml
+++ b/tkn/infra-azure-rhel-ai.yaml
@@ -302,8 +302,8 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 

--- a/tkn/infra-azure-rhel.yaml
+++ b/tkn/infra-azure-rhel.yaml
@@ -301,8 +301,8 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 

--- a/tkn/infra-azure-windows-desktop.yaml
+++ b/tkn/infra-azure-windows-desktop.yaml
@@ -281,11 +281,11 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
           userpassword: $(cat /opt/host-info/userpassword | base64 -w0)
-          adminusername: $(cat /opt/host-info/adminusername | base64 -w0)
+          adminusername: $(cat /opt/host-info/adminusername | tr -d '\n\r' | base64 -w0)
           adminuserpassword: $(cat /opt/host-info/adminuserpassword | base64 -w0)
         EOF
 

--- a/tkn/template/infra-aws-fedora.yaml
+++ b/tkn/template/infra-aws-fedora.yaml
@@ -342,14 +342,14 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
           bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi

--- a/tkn/template/infra-aws-mac.yaml
+++ b/tkn/template/infra-aws-mac.yaml
@@ -294,14 +294,14 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
           bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi

--- a/tkn/template/infra-aws-rhel-ai.yaml
+++ b/tkn/template/infra-aws-rhel-ai.yaml
@@ -350,8 +350,8 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 

--- a/tkn/template/infra-aws-rhel.yaml
+++ b/tkn/template/infra-aws-rhel.yaml
@@ -368,14 +368,14 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ "$(params.airgap)" == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
           bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi

--- a/tkn/template/infra-aws-windows-server.yaml
+++ b/tkn/template/infra-aws-windows-server.yaml
@@ -301,14 +301,14 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
         if [[ $(params.airgap) == "true" ]]; then
         cat <<EOF >> host-info.yaml
-          bastion-host: $(cat /opt/host-info/bastion_host | base64 -w0)
-          bastion-username: $(cat /opt/host-info/bastion_username | base64 -w0)
+          bastion-host: $(cat /opt/host-info/bastion_host | tr -d '\n\r' | base64 -w0)
+          bastion-username: $(cat /opt/host-info/bastion_username | tr -d '\n\r' | base64 -w0)
           bastion-id_rsa: $(cat /opt/host-info/bastion_id_rsa | base64 -w0)
         EOF
         fi

--- a/tkn/template/infra-azure-fedora.yaml
+++ b/tkn/template/infra-azure-fedora.yaml
@@ -297,8 +297,8 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 

--- a/tkn/template/infra-azure-rhel-ai.yaml
+++ b/tkn/template/infra-azure-rhel-ai.yaml
@@ -302,8 +302,8 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 

--- a/tkn/template/infra-azure-rhel.yaml
+++ b/tkn/template/infra-azure-rhel.yaml
@@ -301,8 +301,8 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
         EOF
 

--- a/tkn/template/infra-azure-windows-desktop.yaml
+++ b/tkn/template/infra-azure-windows-desktop.yaml
@@ -281,11 +281,11 @@ spec:
         cat <<EOF >> host-info.yaml
         type: Opaque
         data:
-          host: $(cat /opt/host-info/host | base64 -w0)
-          username: $(cat /opt/host-info/username | base64 -w0)
+          host: $(cat /opt/host-info/host | tr -d '\n\r' | base64 -w0)
+          username: $(cat /opt/host-info/username | tr -d '\n\r' | base64 -w0)
           id_rsa: $(cat /opt/host-info/id_rsa | base64 -w0)
           userpassword: $(cat /opt/host-info/userpassword | base64 -w0)
-          adminusername: $(cat /opt/host-info/adminusername | base64 -w0)
+          adminusername: $(cat /opt/host-info/adminusername | tr -d '\n\r' | base64 -w0)
           adminuserpassword: $(cat /opt/host-info/adminuserpassword | base64 -w0)
         EOF
 


### PR DESCRIPTION
Ensures that `host` and `username` values extracted from files for AWS host-access secrets are properly sanitized.

Previously, these values could include newline or carriage return characters, leading to incorrect base64 encoding and potential issues when creating Kubernetes Opaque secrets. Adding `tr -d '\n\r'` removes these characters, ensuring the secret data is clean and valid.


This PR helps close the issue in redhat-developer/mapt - https://github.com/redhat-developer/mapt/issues/817