### PR TITLE
fix(aws): forward AWS_SESSION_TOKEN to Pulumi provider

### DIFF
--- a/pkg/provider/aws/aws.go
+++ b/pkg/provider/aws/aws.go
@@ -75,7 +75,8 @@ var envCredentials = map[string]string{
 	awsConstants.CONFIG_AWS_REGION:        "AWS_DEFAULT_REGION",
 	awsConstants.CONFIG_AWS_NATIVE_REGION: "AWS_DEFAULT_REGION",
 	awsConstants.CONFIG_AWS_ACCESS_KEY:    "AWS_ACCESS_KEY_ID",
-	awsConstants.CONFIG_AWS_SECRET_KEY:    "AWS_SECRET_ACCESS_KEY"}
+	awsConstants.CONFIG_AWS_SECRET_KEY:    "AWS_SECRET_ACCESS_KEY",
+	awsConstants.CONFIG_AWS_SESSION_TOKEN: "AWS_SESSION_TOKEN"}
 
 var DefaultCredentials = GetClouProviderCredentials(nil)
 

--- a/pkg/provider/aws/constants/constants.go
+++ b/pkg/provider/aws/constants/constants.go
@@ -5,6 +5,7 @@ const (
 	CONFIG_AWS_NATIVE_REGION string = "aws-native:region"
 	CONFIG_AWS_ACCESS_KEY    string = "aws:accessKey"
 	CONFIG_AWS_SECRET_KEY    string = "aws:secretKey"
+	CONFIG_AWS_SESSION_TOKEN string = "aws:token"
 )
 
 const (


### PR DESCRIPTION
This is needed when we use https://github.com/app-sre/rh-aws-saml-login