### PR TITLE
fix(aws): stop storing credentials in Pulumi provider state

### DIFF
--- a/pkg/provider/aws/aws.go
+++ b/pkg/provider/aws/aws.go
@@ -71,12 +71,13 @@ func manageRemoteState(ctx context.Context, backedURL string) error {
 }
 
 // pulumi config key : aws env credential
+// Only region is set via Pulumi config; credentials (access key, secret key,
+// session token) are resolved by the AWS SDK's default credential chain so
+// that expired tokens stored in the Pulumi provider state never shadow
+// fresh environment credentials on later operations (e.g. destroy).
 var envCredentials = map[string]string{
 	awsConstants.CONFIG_AWS_REGION:        "AWS_DEFAULT_REGION",
-	awsConstants.CONFIG_AWS_NATIVE_REGION: "AWS_DEFAULT_REGION",
-	awsConstants.CONFIG_AWS_ACCESS_KEY:    "AWS_ACCESS_KEY_ID",
-	awsConstants.CONFIG_AWS_SECRET_KEY:    "AWS_SECRET_ACCESS_KEY",
-	awsConstants.CONFIG_AWS_SESSION_TOKEN: "AWS_SESSION_TOKEN"}
+	awsConstants.CONFIG_AWS_NATIVE_REGION: "AWS_DEFAULT_REGION"}
 
 var DefaultCredentials = GetClouProviderCredentials(nil)
 

--- a/pkg/provider/aws/constants/constants.go
+++ b/pkg/provider/aws/constants/constants.go
@@ -3,9 +3,6 @@ package constants
 const (
 	CONFIG_AWS_REGION        string = "aws:region"
 	CONFIG_AWS_NATIVE_REGION string = "aws-native:region"
-	CONFIG_AWS_ACCESS_KEY    string = "aws:accessKey"
-	CONFIG_AWS_SECRET_KEY    string = "aws:secretKey"
-	CONFIG_AWS_SESSION_TOKEN string = "aws:token"
 )
 
 const (


### PR DESCRIPTION
AWS credentials (access key, secret key, session token) were being set via Pulumi config, which caused them to be persisted in the provider resource state. When destroying a cluster provisioned with an older session token, Pulumi would use the expired credentials from state instead of the fresh ones from the environment, causing destroy to fail with ExpiredToken errors.

Let the AWS SDK resolve credentials through its default credential chain (env vars, shared credentials file, IAM roles) instead of explicitly setting them in Pulumi config. Only the region is configured explicitly.