### PR TITLE
feat(tkn): add compute-sizes, GPU, and spot-excluded-regions params to SNC task

### DIFF
--- a/tkn/infra-aws-ocp-snc.yaml
+++ b/tkn/infra-aws-ocp-snc.yaml
@@ -97,9 +97,18 @@ spec:
     - name: arch
       description: Architecture for the machine. Allowed x86_64 or arm64 (default "x86_64")
       default: 'x86_64'
-    - name: cpus 
+    - name: compute-sizes
+      description: Comma seperated list of sizes for the machines to be requested. If set this takes precedence over compute by args
+      default: ""
+    - name: cpus
       description: Number of CPUs for the cloud instance (default 8)
       default: '8'
+    - name: gpu-manufacturer
+      description: Manufacturer company name for GPU. (i.e. NVIDIA)
+      default: ""
+    - name: gpus
+      description: Number of GPUs for the cloud instance (default 0)
+      default: "0"
     - name: memory
       description: Amount of RAM for the cloud instance in GiB (default 64)
       default: '64'
@@ -116,10 +125,13 @@ spec:
       description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
       default: '20'
     - name: spot-eviction-tolerance
-      description: | 
-        if spot is enable we can define the minimum tolerance level of eviction. 
+      description: |
+        if spot is enable we can define the minimum tolerance level of eviction.
         Allowed value are: lowest, low, medium, high or highest
       default: 'lowest'
+    - name: spot-excluded-regions
+      description: Comma-separated list of zone IDs to exclude from spot selection
+      default: ""
 
     # OCP params
     - name: version
@@ -243,8 +255,14 @@ spec:
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/cluster-info "
           cmd+="--arch $(params.arch) "
-          cmd+="--cpus $(params.cpus) "
-          cmd+="--memory $(params.memory) "
+          if [[ "$(params.compute-sizes)" != "" ]]; then
+            cmd+="--compute-sizes '$(params.compute-sizes)' "
+          else
+            cmd+="--cpus '$(params.cpus)' "
+            cmd+="--memory '$(params.memory)' "
+            cmd+="--gpus '$(params.gpus)' "
+            cmd+="--gpu-manufacturer '$(params.gpu-manufacturer)' "
+          fi
           if [[ $(params.nested-virt) == "true" ]]; then
             cmd+="--nested-virt "
           fi
@@ -262,8 +280,11 @@ spec:
             cmd+="--profile $(params.profile) "
           fi
           
-          if [[ $(params.spot) == "true" ]]; then 
-            cmd+="--spot --spot-increase-rate $(params.spot-increase-rate) --spot-eviction-tolerance $(params.spot-eviction-tolerance) " 
+          if [[ "$(params.spot)" == "true" ]]; then
+            cmd+="--spot "
+            cmd+="--spot-increase-rate '$(params.spot-increase-rate)' "
+            cmd+="--spot-eviction-tolerance '$(params.spot-eviction-tolerance)' "
+            cmd+="--spot-excluded-regions '$(params.spot-excluded-regions)' "
           fi
           if [[ $(params.timeout) != "" ]]; then
             cmd+="--timeout $(params.timeout) "

--- a/tkn/template/infra-aws-ocp-snc.yaml
+++ b/tkn/template/infra-aws-ocp-snc.yaml
@@ -97,9 +97,18 @@ spec:
     - name: arch
       description: Architecture for the machine. Allowed x86_64 or arm64 (default "x86_64")
       default: 'x86_64'
-    - name: cpus 
+    - name: compute-sizes
+      description: Comma seperated list of sizes for the machines to be requested. If set this takes precedence over compute by args
+      default: ""
+    - name: cpus
       description: Number of CPUs for the cloud instance (default 8)
       default: '8'
+    - name: gpu-manufacturer
+      description: Manufacturer company name for GPU. (i.e. NVIDIA)
+      default: ""
+    - name: gpus
+      description: Number of GPUs for the cloud instance (default 0)
+      default: "0"
     - name: memory
       description: Amount of RAM for the cloud instance in GiB (default 64)
       default: '64'
@@ -116,10 +125,13 @@ spec:
       description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
       default: '20'
     - name: spot-eviction-tolerance
-      description: | 
-        if spot is enable we can define the minimum tolerance level of eviction. 
+      description: |
+        if spot is enable we can define the minimum tolerance level of eviction.
         Allowed value are: lowest, low, medium, high or highest
       default: 'lowest'
+    - name: spot-excluded-regions
+      description: Comma-separated list of zone IDs to exclude from spot selection
+      default: ""
 
     # OCP params
     - name: version
@@ -243,8 +255,14 @@ spec:
         if [[ $(params.operation) == "create" ]]; then
           cmd+="--conn-details-output /opt/cluster-info "
           cmd+="--arch $(params.arch) "
-          cmd+="--cpus $(params.cpus) "
-          cmd+="--memory $(params.memory) "
+          if [[ "$(params.compute-sizes)" != "" ]]; then
+            cmd+="--compute-sizes '$(params.compute-sizes)' "
+          else
+            cmd+="--cpus '$(params.cpus)' "
+            cmd+="--memory '$(params.memory)' "
+            cmd+="--gpus '$(params.gpus)' "
+            cmd+="--gpu-manufacturer '$(params.gpu-manufacturer)' "
+          fi
           if [[ $(params.nested-virt) == "true" ]]; then
             cmd+="--nested-virt "
           fi
@@ -262,8 +280,11 @@ spec:
             cmd+="--profile $(params.profile) "
           fi
           
-          if [[ $(params.spot) == "true" ]]; then 
-            cmd+="--spot --spot-increase-rate $(params.spot-increase-rate) --spot-eviction-tolerance $(params.spot-eviction-tolerance) " 
+          if [[ "$(params.spot)" == "true" ]]; then
+            cmd+="--spot "
+            cmd+="--spot-increase-rate '$(params.spot-increase-rate)' "
+            cmd+="--spot-eviction-tolerance '$(params.spot-eviction-tolerance)' "
+            cmd+="--spot-excluded-regions '$(params.spot-excluded-regions)' "
           fi
           if [[ $(params.timeout) != "" ]]; then
             cmd+="--timeout $(params.timeout) "


### PR DESCRIPTION
## Summary

- Add `compute-sizes`, `gpus`, `gpu-manufacturer`, and `spot-excluded-regions` params to the SNC Tekton task template
- When `compute-sizes` is set, it takes precedence over `cpus`/`memory`/`gpus` args (same pattern as RHEL task)
- Regenerated `tkn/infra-aws-ocp-snc.yaml` via `make tkn-update`

Closes #858

## Verification results

### Script logic dry-run (3 scenarios)

| Scenario | compute-sizes | spot | Result |
|---|---|---|---|
| compute-sizes + spot + excluded regions | `m5.xlarge,m5.2xlarge` | on | `--compute-sizes` used, no `--cpus/--memory/--gpus`, all spot flags present |
| empty compute-sizes (fallback) | empty | on | Falls back to `--cpus/--memory/--gpus/--gpu-manufacturer`, spot flags present |
| compute-sizes + spot off | `c5.4xlarge` | off | `--compute-sizes` used, zero spot flags |

### Live Tekton TaskRun (OCP 4.21.0 cluster)

Deployed SNO cluster, installed OpenShift Pipelines v1.22.4, applied the modified task, and ran a TaskRun with `debug=true` to inspect the built command. Debug output confirms correct param resolution:

```
mapt aws ocp-snc create \
  --arch x86_64 \
  --compute-sizes m5.4xlarge,m6i.4xlarge \
  --disk-size 200 \
  --spot \
  --spot-increase-rate 20 \
  --spot-eviction-tolerance lowest \
  --spot-excluded-regions us-east-1a,us-west-2b
```

- `--compute-sizes` present, `--cpus`/`--memory`/`--gpus` correctly absent (if/else branch works)
- `--spot-excluded-regions` passed through with correct value
- No `--cpus`/`--memory` leakage when `compute-sizes` is set

## Test plan

- [x] Verify generated YAML matches template (only `<IMAGE>`/`<VERSION>` substitution differs)
- [x] Dry-run script logic with param substitution — all 3 scenarios pass
- [x] Live Tekton TaskRun with `compute-sizes` set — confirmed `--compute-sizes` used, no fallback params
- [x] Live Tekton TaskRun with `spot-excluded-regions` — confirmed value passed through
- [ ] Run SNC task without `compute-sizes` — confirm fallback to `cpus`/`memory`/`gpus` works as before (covered by dry-run scenario 2)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)