### PR TITLE
fix(cve): bump ose-cli from 4.13 to v4.15 for CVE-2026-33747

### DIFF
--- a/tkn/infra-aws-eks.yaml
+++ b/tkn/infra-aws-eks.yaml
@@ -248,7 +248,7 @@ spec:
           memory: "600Mi"
           cpu: "300m"
     - name: cluster-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-aws-fedora.yaml
+++ b/tkn/infra-aws-fedora.yaml
@@ -301,7 +301,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-aws-kind.yaml
+++ b/tkn/infra-aws-kind.yaml
@@ -261,7 +261,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-aws-mac.yaml
+++ b/tkn/infra-aws-mac.yaml
@@ -253,7 +253,7 @@ spec:
           cpu: "300m"
           
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-aws-ocp-snc.yaml
+++ b/tkn/infra-aws-ocp-snc.yaml
@@ -314,7 +314,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-aws-rhel-ai.yaml
+++ b/tkn/infra-aws-rhel-ai.yaml
@@ -345,7 +345,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-aws-rhel.yaml
+++ b/tkn/infra-aws-rhel.yaml
@@ -327,7 +327,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-aws-windows-server.yaml
+++ b/tkn/infra-aws-windows-server.yaml
@@ -260,7 +260,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-azure-aks.yaml
+++ b/tkn/infra-azure-aks.yaml
@@ -217,7 +217,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-azure-fedora.yaml
+++ b/tkn/infra-azure-fedora.yaml
@@ -256,7 +256,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-azure-rhel-ai.yaml
+++ b/tkn/infra-azure-rhel-ai.yaml
@@ -279,7 +279,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-azure-rhel.yaml
+++ b/tkn/infra-azure-rhel.yaml
@@ -260,7 +260,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/infra-azure-windows-desktop.yaml
+++ b/tkn/infra-azure-windows-desktop.yaml
@@ -240,7 +240,7 @@ spec:
           memory: "2Gi"
           cpu: "1000m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-aws-eks.yaml
+++ b/tkn/template/infra-aws-eks.yaml
@@ -248,7 +248,7 @@ spec:
           memory: "600Mi"
           cpu: "300m"
     - name: cluster-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-aws-fedora.yaml
+++ b/tkn/template/infra-aws-fedora.yaml
@@ -301,7 +301,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-aws-kind.yaml
+++ b/tkn/template/infra-aws-kind.yaml
@@ -261,7 +261,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-aws-mac.yaml
+++ b/tkn/template/infra-aws-mac.yaml
@@ -253,7 +253,7 @@ spec:
           cpu: "300m"
           
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-aws-ocp-snc.yaml
+++ b/tkn/template/infra-aws-ocp-snc.yaml
@@ -314,7 +314,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-aws-rhel-ai.yaml
+++ b/tkn/template/infra-aws-rhel-ai.yaml
@@ -345,7 +345,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-aws-rhel.yaml
+++ b/tkn/template/infra-aws-rhel.yaml
@@ -327,7 +327,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-aws-windows-server.yaml
+++ b/tkn/template/infra-aws-windows-server.yaml
@@ -260,7 +260,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-azure-aks.yaml
+++ b/tkn/template/infra-azure-aks.yaml
@@ -217,7 +217,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-azure-fedora.yaml
+++ b/tkn/template/infra-azure-fedora.yaml
@@ -256,7 +256,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-azure-rhel-ai.yaml
+++ b/tkn/template/infra-azure-rhel-ai.yaml
@@ -279,7 +279,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-azure-rhel.yaml
+++ b/tkn/template/infra-azure-rhel.yaml
@@ -260,7 +260,7 @@ spec:
           memory: "2Gi"
           cpu: "300m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)

--- a/tkn/template/infra-azure-windows-desktop.yaml
+++ b/tkn/template/infra-azure-windows-desktop.yaml
@@ -240,7 +240,7 @@ spec:
           memory: "2Gi"
           cpu: "1000m"
     - name: host-info-secret
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      image: registry.redhat.io/openshift4/ose-cli:v4.15@sha256:9dbec69c215a4041a49bec977a7c2013b5bafe335201d5e983422f30a7e434a2
       env:
         - name: NAMESPACE
           value: $(context.taskRun.namespace)


### PR DESCRIPTION
## Summary
- Bumps `ose-cli` from `4.13` to `v4.15` (digest-pinned) across all 26 Tekton task YAMLs
- Addresses critical BuildKit file escape vulnerability (CVE-2026-33747)

## References
- [CVE-2026-33747](https://nvd.nist.gov/vuln/detail/CVE-2026-33747)