### PR TITLE
feat(tkn): add operator-channel param to infra-aws-ocp-snc task

### DIFF
--- a/tkn/infra-aws-fedora.yaml
+++ b/tkn/infra-aws-fedora.yaml
@@ -91,6 +91,9 @@ spec:
     - name: cpus
       description: Number of CPUs for the cloud instance (default 8)
       default: "8"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: gpu-manufacturer
       description: Manufacturer company name for GPU. (i.e. NVIDIA)
       default: ""
@@ -103,15 +106,12 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
-    - name: disk-size
-      description: Disk size in GB for the cloud instance
-      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
     - name: spot-eviction-tolerance
-      description: | 
-        If spot is enabled we can define the minimum tolerance level of eviction. 
+      description: |
+        If spot is enabled we can define the minimum tolerance level of eviction.
         Allowed value are: lowest, low, medium, high or highest
       default: "lowest"
     - name: spot-excluded-regions

--- a/tkn/infra-aws-kind.yaml
+++ b/tkn/infra-aws-kind.yaml
@@ -82,29 +82,29 @@ spec:
     - name: arch
       description: Architecture for the machine. Allowed x86_64 or arm64 (default "x86_64")
       default: 'x86_64'
-    - name: cpus 
+    - name: cpus
       description: Number of CPUs for the cloud instance (default 8)
       default: '8'
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
     - name: memory
       description: Amount of RAM for the cloud instance in GiB (default 64)
       default: '64'
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: 'false'
-    - name: disk-size
-      description: Disk size in GB for the cloud instance
-      default: '200'
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: 'true'
+    - name: spot-eviction-tolerance
+      description: |
+        if spot is enable we can define the minimum tolerance level of eviction.
+        Allowed value are: lowest, low, medium, high or highest
+      default: 'lowest'
     - name: spot-increase-rate
       description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
       default: '20'
-    - name: spot-eviction-tolerance
-      description: | 
-        if spot is enable we can define the minimum tolerance level of eviction. 
-        Allowed value are: lowest, low, medium, high or highest
-      default: 'lowest'
 
     # OCP params
     - name: version

--- a/tkn/infra-aws-ocp-snc.yaml
+++ b/tkn/infra-aws-ocp-snc.yaml
@@ -103,6 +103,9 @@ spec:
     - name: cpus
       description: Number of CPUs for the cloud instance (default 8)
       default: '8'
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
     - name: gpu-manufacturer
       description: Manufacturer company name for GPU. (i.e. NVIDIA)
       default: ""
@@ -115,15 +118,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: 'false'
-    - name: disk-size
-      description: Disk size in GB for the cloud instance
-      default: '200'
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: 'true'
-    - name: spot-increase-rate
-      description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
-      default: '20'
     - name: spot-eviction-tolerance
       description: |
         if spot is enable we can define the minimum tolerance level of eviction.
@@ -132,6 +129,9 @@ spec:
     - name: spot-excluded-regions
       description: Comma-separated list of zone IDs to exclude from spot selection
       default: ""
+    - name: spot-increase-rate
+      description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
+      default: '20'
 
     # OCP params
     - name: version
@@ -140,6 +140,12 @@ spec:
     - name: disable-cluster-readiness
       description: If this flag is set it will skip the checks for the cluster readiness. In this case the kubeconfig can not be generated.
       default: 'false'
+    - name: operator-channel
+      description: |
+        Comma-separated list of operator channel overrides in the form package=channel
+        (e.g. rhods-operator=stable-3.x). Overrides the default OLM channel for the
+        named operator. Multiple overrides can be separated by commas.
+      default: ""
     - name: profile
       description: Comma-separated list of profiles to install on the cluster (e.g. virtualization, serverless-serving, serverless-eventing, serverless, servicemesh, ai). When virtualization is selected, a bare metal instance is used.
       default: "''"
@@ -244,7 +250,7 @@ spec:
         fi
 
         # Run mapt
-        cmd="mapt aws ocp-snc $(params.operation) "
+        cmd="mapt aws openshift-snc $(params.operation) "
         cmd+="--project-name ocp-snc-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/ocp-snc/$(params.id) "
 
@@ -279,7 +285,17 @@ spec:
           if [[ $(params.profile) != "" ]]; then
             cmd+="--profile $(params.profile) "
           fi
-          
+          if [[ "$(params.operator-channel)" != "" ]]; then
+            IFS=',' read -ra channels <<< "$(params.operator-channel)"
+            for ch in "${channels[@]}"; do
+              if [[ ! "${ch}" =~ ^[a-zA-Z0-9_-]+=[a-zA-Z0-9._-]+$ ]]; then
+                echo "ERROR: invalid operator-channel value: ${ch}" >&2
+                exit 1
+              fi
+              cmd+="--operator-channel $(printf '%q' "${ch}") "
+            done
+          fi
+
           if [[ "$(params.spot)" == "true" ]]; then
             cmd+="--spot "
             cmd+="--spot-increase-rate '$(params.spot-increase-rate)' "

--- a/tkn/infra-aws-rhel-ai.yaml
+++ b/tkn/infra-aws-rhel-ai.yaml
@@ -106,6 +106,9 @@ spec:
     - name: custom-image
       description: Custom image name to use for the cloud instance
       default: ""
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: gpu-manufacturer
       description: Manufacturer company name for GPU. (i.e. NVIDIA)
       default: ""
@@ -118,15 +121,12 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
-    - name: disk-size
-      description: Disk size in GB for the cloud instance
-      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
     - name: spot-eviction-tolerance
-      description: | 
-        If spot is enabled we can define the minimum tolerance level of eviction. 
+      description: |
+        If spot is enabled we can define the minimum tolerance level of eviction.
         Allowed value are: lowest, low, medium, high or highest
       default: "lowest"
     - name: spot-excluded-regions

--- a/tkn/infra-aws-rhel.yaml
+++ b/tkn/infra-aws-rhel.yaml
@@ -106,6 +106,9 @@ spec:
     - name: cpus
       description: Number of CPUs for the cloud instance (default 8)
       default: "8"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: gpu-manufacturer
       description: Manufacturer company name for GPU. (i.e. NVIDIA)
       default: ""
@@ -118,15 +121,12 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
-    - name: disk-size
-      description: Disk size in GB for the cloud instance
-      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
     - name: spot-eviction-tolerance
-      description: | 
-        If spot is enabled we can define the minimum tolerance level of eviction. 
+      description: |
+        If spot is enabled we can define the minimum tolerance level of eviction.
         Allowed value are: lowest, low, medium, high or highest
       default: "lowest"
     - name: spot-excluded-regions

--- a/tkn/template/infra-aws-fedora.yaml
+++ b/tkn/template/infra-aws-fedora.yaml
@@ -91,6 +91,9 @@ spec:
     - name: cpus
       description: Number of CPUs for the cloud instance (default 8)
       default: "8"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: gpu-manufacturer
       description: Manufacturer company name for GPU. (i.e. NVIDIA)
       default: ""
@@ -103,15 +106,12 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
-    - name: disk-size
-      description: Disk size in GB for the cloud instance
-      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
     - name: spot-eviction-tolerance
-      description: | 
-        If spot is enabled we can define the minimum tolerance level of eviction. 
+      description: |
+        If spot is enabled we can define the minimum tolerance level of eviction.
         Allowed value are: lowest, low, medium, high or highest
       default: "lowest"
     - name: spot-excluded-regions

--- a/tkn/template/infra-aws-kind.yaml
+++ b/tkn/template/infra-aws-kind.yaml
@@ -82,29 +82,29 @@ spec:
     - name: arch
       description: Architecture for the machine. Allowed x86_64 or arm64 (default "x86_64")
       default: 'x86_64'
-    - name: cpus 
+    - name: cpus
       description: Number of CPUs for the cloud instance (default 8)
       default: '8'
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
     - name: memory
       description: Amount of RAM for the cloud instance in GiB (default 64)
       default: '64'
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: 'false'
-    - name: disk-size
-      description: Disk size in GB for the cloud instance
-      default: '200'
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: 'true'
+    - name: spot-eviction-tolerance
+      description: |
+        if spot is enable we can define the minimum tolerance level of eviction.
+        Allowed value are: lowest, low, medium, high or highest
+      default: 'lowest'
     - name: spot-increase-rate
       description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
       default: '20'
-    - name: spot-eviction-tolerance
-      description: | 
-        if spot is enable we can define the minimum tolerance level of eviction. 
-        Allowed value are: lowest, low, medium, high or highest
-      default: 'lowest'
 
     # OCP params
     - name: version

--- a/tkn/template/infra-aws-ocp-snc.yaml
+++ b/tkn/template/infra-aws-ocp-snc.yaml
@@ -103,6 +103,9 @@ spec:
     - name: cpus
       description: Number of CPUs for the cloud instance (default 8)
       default: '8'
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: '200'
     - name: gpu-manufacturer
       description: Manufacturer company name for GPU. (i.e. NVIDIA)
       default: ""
@@ -115,15 +118,9 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: 'false'
-    - name: disk-size
-      description: Disk size in GB for the cloud instance
-      default: '200'
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: 'true'
-    - name: spot-increase-rate
-      description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
-      default: '20'
     - name: spot-eviction-tolerance
       description: |
         if spot is enable we can define the minimum tolerance level of eviction.
@@ -132,6 +129,9 @@ spec:
     - name: spot-excluded-regions
       description: Comma-separated list of zone IDs to exclude from spot selection
       default: ""
+    - name: spot-increase-rate
+      description: Percentage to be added on top of the current calculated spot price to increase chances to get the machine.
+      default: '20'
 
     # OCP params
     - name: version
@@ -140,6 +140,12 @@ spec:
     - name: disable-cluster-readiness
       description: If this flag is set it will skip the checks for the cluster readiness. In this case the kubeconfig can not be generated.
       default: 'false'
+    - name: operator-channel
+      description: |
+        Comma-separated list of operator channel overrides in the form package=channel
+        (e.g. rhods-operator=stable-3.x). Overrides the default OLM channel for the
+        named operator. Multiple overrides can be separated by commas.
+      default: ""
     - name: profile
       description: Comma-separated list of profiles to install on the cluster (e.g. virtualization, serverless-serving, serverless-eventing, serverless, servicemesh, ai). When virtualization is selected, a bare metal instance is used.
       default: "''"
@@ -244,7 +250,7 @@ spec:
         fi
 
         # Run mapt
-        cmd="mapt aws ocp-snc $(params.operation) "
+        cmd="mapt aws openshift-snc $(params.operation) "
         cmd+="--project-name ocp-snc-$(params.id) "
         cmd+="--backed-url s3://${BUCKET}/mapt/ocp-snc/$(params.id) "
 
@@ -279,7 +285,17 @@ spec:
           if [[ $(params.profile) != "" ]]; then
             cmd+="--profile $(params.profile) "
           fi
-          
+          if [[ "$(params.operator-channel)" != "" ]]; then
+            IFS=',' read -ra channels <<< "$(params.operator-channel)"
+            for ch in "${channels[@]}"; do
+              if [[ ! "${ch}" =~ ^[a-zA-Z0-9_-]+=[a-zA-Z0-9._-]+$ ]]; then
+                echo "ERROR: invalid operator-channel value: ${ch}" >&2
+                exit 1
+              fi
+              cmd+="--operator-channel $(printf '%q' "${ch}") "
+            done
+          fi
+
           if [[ "$(params.spot)" == "true" ]]; then
             cmd+="--spot "
             cmd+="--spot-increase-rate '$(params.spot-increase-rate)' "

--- a/tkn/template/infra-aws-rhel-ai.yaml
+++ b/tkn/template/infra-aws-rhel-ai.yaml
@@ -106,6 +106,9 @@ spec:
     - name: custom-image
       description: Custom image name to use for the cloud instance
       default: ""
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: gpu-manufacturer
       description: Manufacturer company name for GPU. (i.e. NVIDIA)
       default: ""
@@ -118,15 +121,12 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
-    - name: disk-size
-      description: Disk size in GB for the cloud instance
-      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
     - name: spot-eviction-tolerance
-      description: | 
-        If spot is enabled we can define the minimum tolerance level of eviction. 
+      description: |
+        If spot is enabled we can define the minimum tolerance level of eviction.
         Allowed value are: lowest, low, medium, high or highest
       default: "lowest"
     - name: spot-excluded-regions

--- a/tkn/template/infra-aws-rhel.yaml
+++ b/tkn/template/infra-aws-rhel.yaml
@@ -106,6 +106,9 @@ spec:
     - name: cpus
       description: Number of CPUs for the cloud instance (default 8)
       default: "8"
+    - name: disk-size
+      description: Disk size in GB for the cloud instance
+      default: "200"
     - name: gpu-manufacturer
       description: Manufacturer company name for GPU. (i.e. NVIDIA)
       default: ""
@@ -118,15 +121,12 @@ spec:
     - name: nested-virt
       description: Use cloud instance that has nested virtualization support
       default: "false"
-    - name: disk-size
-      description: Disk size in GB for the cloud instance
-      default: "200"
     - name: spot
       description: Check best spot option to spin the machine and will create resources on that region.
       default: "true"
     - name: spot-eviction-tolerance
-      description: | 
-        If spot is enabled we can define the minimum tolerance level of eviction. 
+      description: |
+        If spot is enabled we can define the minimum tolerance level of eviction.
         Allowed value are: lowest, low, medium, high or highest
       default: "lowest"
     - name: spot-excluded-regions


### PR DESCRIPTION
## Summary

Exposes the \`--operator-channel\` CLI flag (added in #806) as a Tekton task param so callers can override OLM subscription channels per operator without rebuilding the image.

**Use case**: pass \`rhods-operator=stable-3.x\` to install RHOAI 3.x instead of the default \`stable\` channel (RHOAI 2.25.x).

## Changes

- \`tkn/infra-aws-ocp-snc.yaml\` + \`tkn/template/infra-aws-ocp-snc.yaml\`: new \`operator-channel\` param (default empty = use mapt default channel). Comma-separated \`package=channel\` pairs each passed as \`--operator-channel\` to mapt. Input validated against \`^[a-zA-Z0-9_-]+=[a-zA-Z0-9._-]+$\` and shell-escaped before eval to prevent injection.
- Fixed: \`mapt aws ocp-snc\` → \`mapt aws openshift-snc\` (current binary uses \`openshift-snc\`, alias not yet available).

## Example
```yaml
- name: operator-channel
  value: "rhods-operator=stable-3.x"`
```




## E2E Test Results (2026-07-30) ✅

Validated via RHAIIS-on-RHOAI ITS pipeline run \`rhaiis-rhoai-e2e-3x-test6\` on OCP 4.21.14:

| Task | Status | Duration |
|------|--------|----------|
| create-snc-cluster (RHOAI 3.3.x via stable-3.x) | ✅ Succeeded | 20m54s |
| deploy-and-test-kserve | ✅ Succeeded | 5m19s |
| delete-snc-cluster | ✅ Succeeded | 4m15s |

```
✓ Verification PASSED: Response contains 'Paris'
=== RHAIIS on RHOAI smoke test PASSED ===
```

RHOAI 3.x confirmed by presence of \`llminferenceservices\` (llmisvc) CRD, which is new in 3.x and absent in 2.25.x. Related: [AIPCC-28556](https://redhat.atlassian.net/browse/AIPCC-28556), konflux-data [MR !447](https://gitlab.com/redhat/rhel-ai/konflux-data/-/merge_requests/447).

🤖 Generated with [Claude Code](https://claude.com/claude-code)