### PR TITLE
fix(tkn): make ocp-snc-credentials secret optional in infra-aws-ocp-snc

### DIFF
--- a/tkn/infra-aws-ocp-snc.yaml
+++ b/tkn/infra-aws-ocp-snc.yaml
@@ -22,6 +22,7 @@ spec:
     - name: ocp-snc-credentials
       secret:
         secretName: $(params.secret-ocp-snc-credentials)
+        optional: true
     - name: cluster-info
       emptyDir: {}
 
@@ -43,8 +44,13 @@ spec:
           region: ${region}
           bucket: ${bucket}
     - name: secret-ocp-snc-credentials
+      default: "non-existent-secret"
       description: |
         ocp secret holding the ocp snc credentials. Secret should be accessible to this task.
+        Not required for the destroy operation.
+
+        As this credentials are optional we set a non-existent name for the secret which
+        will be mounted as an empty volume
 
         ---
         apiVersion: v1

--- a/tkn/template/infra-aws-ocp-snc.yaml
+++ b/tkn/template/infra-aws-ocp-snc.yaml
@@ -22,6 +22,7 @@ spec:
     - name: ocp-snc-credentials
       secret:
         secretName: $(params.secret-ocp-snc-credentials)
+        optional: true
     - name: cluster-info
       emptyDir: {}
 
@@ -43,8 +44,13 @@ spec:
           region: ${region}
           bucket: ${bucket}
     - name: secret-ocp-snc-credentials
+      default: "non-existent-secret"
       description: |
         ocp secret holding the ocp snc credentials. Secret should be accessible to this task.
+        Not required for the destroy operation.
+
+        As this credentials are optional we set a non-existent name for the secret which
+        will be mounted as an empty volume
 
         ---
         apiVersion: v1


### PR DESCRIPTION
## Summary

- \`infra-aws-ocp-snc.yaml\`'s \`pull-secret\` (from \`secret-ocp-snc-credentials\`) is only read during the \`create\` operation, but the volume mount was unconditional and the param had no default, so \`destroy\` calls fail to schedule unless a secret with that exact name already exists in the cluster.
- Marks the \`ocp-snc-credentials\` volume's secret as \`optional: true\` and defaults the \`secret-ocp-snc-credentials\` param to \`"''"\`, so \`destroy\` can run without requiring an unrelated secret to exist.