### PR TITLE
fix(aws): tag IAM role/instance-profile and spot ASG with mapt resource tags

### DIFF
--- a/pkg/provider/aws/action/snc/snc.go
+++ b/pkg/provider/aws/action/snc/snc.go
@@ -213,7 +213,7 @@ func (r *openshiftSNCRequest) deploy(ctx *pulumi.Context) error {
 		return err
 	}
 	// Instance profile required by logic within userdata
-	iProfile, err := iam.InstanceProfile(ctx, r.prefix, &apiSNC.OCPSNCID, requiredPolicies)
+	iProfile, err := iam.InstanceProfile(ctx, r.mCtx, r.prefix, &apiSNC.OCPSNCID, requiredPolicies)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/aws/modules/bastion/bastion.go
+++ b/pkg/provider/aws/modules/bastion/bastion.go
@@ -129,6 +129,7 @@ func instance(ctx *pulumi.Context, mCtx *mc.Context, args *instaceArgs) (*ec2.In
 		VpcSecurityGroupIds:      args.securityGroups,
 		RootBlockDevice: ec2.InstanceRootBlockDeviceArgs{
 			VolumeSize: pulumi.Int(diskSize),
+			Tags:       mCtx.ResourceTags(),
 		},
 		Tags: mCtx.ResourceTags(),
 	}

--- a/pkg/provider/aws/modules/ec2/compute/compute.go
+++ b/pkg/provider/aws/modules/ec2/compute/compute.go
@@ -116,6 +116,7 @@ func (r *ComputeRequest) onDemandInstance(ctx *pulumi.Context) (*ec2.Instance, e
 		VpcSecurityGroupIds:      r.SecurityGroups,
 		RootBlockDevice: ec2.InstanceRootBlockDeviceArgs{
 			VolumeSize: pulumi.Int(volSize),
+			Tags:       r.MCtx.ResourceTags(),
 		},
 		Tags: r.MCtx.ResourceTags(),
 	}
@@ -243,6 +244,20 @@ func (r ComputeRequest) spotInstance(ctx *pulumi.Context) (*autoscaling.Group, e
 			Overrides: overrides,
 		},
 	}
+	asgTags := autoscaling.GroupTagArray{
+		&autoscaling.GroupTagArgs{
+			Key:               pulumi.String("Name"),
+			Value:             pulumi.String(resourcesUtil.GetResourceName(r.Prefix, r.ID, "asg")),
+			PropagateAtLaunch: pulumi.Bool(true),
+		},
+	}
+	for key, value := range r.MCtx.ResourceTags() {
+		asgTags = append(asgTags, &autoscaling.GroupTagArgs{
+			Key:               pulumi.String(key),
+			Value:             value,
+			PropagateAtLaunch: pulumi.Bool(true),
+		})
+	}
 	return autoscaling.NewGroup(ctx,
 		resourcesUtil.GetResourceName(r.Prefix, r.ID, "asg"),
 		&autoscaling.GroupArgs{
@@ -262,13 +277,7 @@ func (r ComputeRequest) spotInstance(ctx *pulumi.Context) (*autoscaling.Group, e
 			// Skip waiting for instances to fully terminate on destroy;
 			// these are ephemeral machines so there is no need to drain.
 			ForceDelete: pulumi.Bool(true),
-			Tags: autoscaling.GroupTagArray{
-				&autoscaling.GroupTagArgs{
-					Key:               pulumi.String("Name"),
-					Value:             pulumi.String(resourcesUtil.GetResourceName(r.Prefix, r.ID, "asg")),
-					PropagateAtLaunch: pulumi.Bool(true),
-				},
-			},
+			Tags:        asgTags,
 		},
 		pulumi.Timeouts(&pulumi.CustomTimeouts{
 			Delete: "30m"}),

--- a/pkg/provider/aws/modules/iam/iam.go
+++ b/pkg/provider/aws/modules/iam/iam.go
@@ -6,11 +6,12 @@ import (
 	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/iam"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
+	mc "github.com/redhat-developer/mapt/pkg/manager/context"
 	resourcesUtil "github.com/redhat-developer/mapt/pkg/util/resources"
 )
 
 // Create a instance profile based on a list of policies
-func InstanceProfile(ctx *pulumi.Context, prefix, id *string, policiesARNs []string) (*iam.InstanceProfile, error) {
+func InstanceProfile(ctx *pulumi.Context, mCtx *mc.Context, prefix, id *string, policiesARNs []string) (*iam.InstanceProfile, error) {
 	r, err := iam.NewRole(ctx,
 		resourcesUtil.GetResourceName(*prefix, *id, "ec2-role"),
 		&iam.RoleArgs{
@@ -24,6 +25,7 @@ func InstanceProfile(ctx *pulumi.Context, prefix, id *string, policiesARNs []str
 				}
 			]
 		}`),
+			Tags: mCtx.ResourceTags(),
 		})
 	if err != nil {
 		return nil, err
@@ -40,9 +42,11 @@ func InstanceProfile(ctx *pulumi.Context, prefix, id *string, policiesARNs []str
 		}
 	}
 	return iam.NewInstanceProfile(ctx,
-		resourcesUtil.GetResourceName(*prefix, *id, "instance-profie"),
+		resourcesUtil.GetResourceName(*prefix, *id, "instance-profile"),
 		&iam.InstanceProfileArgs{
-			Role: r})
+			Role: r,
+			Tags: mCtx.ResourceTags(),
+		})
 }
 
 func (r *iamRequestArgs) deploy(ctx *pulumi.Context) error {

--- a/pkg/provider/aws/modules/mac/machine/machine.go
+++ b/pkg/provider/aws/modules/mac/machine/machine.go
@@ -336,6 +336,7 @@ func (r *Request) instance(ctx *pulumi.Context,
 		VpcSecurityGroupIds:      securityGroups,
 		RootBlockDevice: ec2.InstanceRootBlockDeviceArgs{
 			VolumeSize: pulumi.Int(diskSize),
+			Tags:       r.MCtx.ResourceTags(),
 		},
 		Tags: r.MCtx.ResourceTags(),
 	}


### PR DESCRIPTION
The EC2 role, instance profile, spot Auto Scaling Group, and on-demand instances' root EBS volumes were untagged, making orphaned resources (from interrupted destroys) hard to identify and clean up. Also fixes a naming typo (instance-profie -> instance-profile).