### PR TITLE
fix(otel): migrate to OTLP header-based authentication

### DIFF
--- a/pkg/integrations/otelcol/snippet-linux.sh
+++ b/pkg/integrations/otelcol/snippet-linux.sh
@@ -182,9 +182,6 @@ processors:
       - key: appcode
         value: "{{.AppCode}}"
         action: upsert
-      - key: com.redhat.otel.auth_token
-        value: "${env:OTEL_AUTH_TOKEN}"
-        action: upsert
       - key: arch
         value: "{{.Arch}}"
         action: upsert
@@ -196,6 +193,8 @@ processors:
 exporters:
   otlphttp:
     endpoint: "{{.Endpoint}}"
+    headers:
+      Authorization: "Bearer ${env:OTEL_AUTH_TOKEN}"
     tls:
       insecure_skip_verify: true
 service:


### PR DESCRIPTION
## Summary

- Remove the interim resource-attribute token injection (`com.redhat.otel.auth_token`) from the otelcol-contrib collector config
- Add a standard `Authorization: Bearer` header on the `otlphttp` exporter for authenticated OTLP delivery
- Aligns with internal Enterprise Security Standard (ESS) requirements for authenticated OTLP data delivery

The configured endpoint default was already correct; no endpoint changes needed in code. Any secrets storing the old endpoint URL with an explicit port should be updated to use the new authenticated endpoint.

## Test plan

- [x] Deploy a VM/instance with `--otel-app-code` and `--otel-auth-token` set
- [x] Verify otelcol-contrib service starts and the `Authorization` header is present in outbound OTLP requests to the configured endpoint
- [ ] Confirm logs appear in the expected Splunk index

🤖 Generated with [Claude Code](https://claude.com/claude-code)