### PR TITLE
fix(tkn): export AWS session token in SNC task

### DIFF
--- a/tkn/infra-aws-ocp-snc.yaml
+++ b/tkn/infra-aws-ocp-snc.yaml
@@ -243,12 +243,20 @@ spec:
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
 
+        # Support temporary session tokens (SAML/STS credentials)
+        if [[ -f /opt/aws-credentials/session-token ]]; then
+          export AWS_SESSION_TOKEN=$(cat /opt/aws-credentials/session-token)
+        fi
+
         # If debug add verbosity and print masked credentials
         if [[ $(params.debug) == "true" ]]; then
           echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
           echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
           echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
           echo "BUCKET=$BUCKET"
+          if [[ -n "${AWS_SESSION_TOKEN:-}" ]]; then
+            echo "AWS_SESSION_TOKEN=$(mask_credential "$AWS_SESSION_TOKEN")"
+          fi
           set -xeuo pipefail
         fi
 

--- a/tkn/template/infra-aws-ocp-snc.yaml
+++ b/tkn/template/infra-aws-ocp-snc.yaml
@@ -243,12 +243,20 @@ spec:
         export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
         BUCKET=$(cat /opt/aws-credentials/bucket)
 
+        # Support temporary session tokens (SAML/STS credentials)
+        if [[ -f /opt/aws-credentials/session-token ]]; then
+          export AWS_SESSION_TOKEN=$(cat /opt/aws-credentials/session-token)
+        fi
+
         # If debug add verbosity and print masked credentials
         if [[ $(params.debug) == "true" ]]; then
           echo "AWS_ACCESS_KEY_ID=$(mask_credential "$AWS_ACCESS_KEY_ID")"
           echo "AWS_SECRET_ACCESS_KEY=$(mask_credential "$AWS_SECRET_ACCESS_KEY")"
           echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
           echo "BUCKET=$BUCKET"
+          if [[ -n "${AWS_SESSION_TOKEN:-}" ]]; then
+            echo "AWS_SESSION_TOKEN=$(mask_credential "$AWS_SESSION_TOKEN")"
+          fi
           set -xeuo pipefail
         fi
 


### PR DESCRIPTION
## What

Export the optional `session-token` mounted by the AWS credentials secret as `AWS_SESSION_TOKEN` before invoking mapt. This enables temporary SAML/STS credentials in the `infra-aws-ocp-snc` Tekton task.

The generated task and its source template are updated together. The token is masked in debug output.

## Validation

- YAML parsing passed for both task manifests.
- `git diff --check` passed.
- Go tests could not run locally because the checkout requires Go 1.26 and the environment provides Go 1.25.

Generated with Codex.