### PR TITLE
fix(aws): wait for EIP association before readiness

### DIFF
--- a/pkg/provider/aws/modules/ec2/compute/compute.go
+++ b/pkg/provider/aws/modules/ec2/compute/compute.go
@@ -92,15 +92,16 @@ func (r *ComputeRequest) NewCompute(ctx *pulumi.Context) (*Compute, error) {
 			Eip:              r.Eip,
 			Dependencies:     []pulumi.Resource{asg, r.LB, r.Eip}}, err
 	}
-	i, err := r.onDemandInstance(ctx)
+	i, eipAssociation, err := r.onDemandInstance(ctx)
 	return &Compute{
 		Instance:     i,
 		Eip:          r.Eip,
-		Dependencies: []pulumi.Resource{i, r.Eip}}, err
+		// Commands use the EIP, so they must not start before it is attached.
+		Dependencies: []pulumi.Resource{eipAssociation}}, err
 }
 
 // Create on demand instance
-func (r *ComputeRequest) onDemandInstance(ctx *pulumi.Context) (*ec2.Instance, error) {
+func (r *ComputeRequest) onDemandInstance(ctx *pulumi.Context) (*ec2.Instance, *ec2.EipAssociation, error) {
 	volSize := diskSize
 	if r.DiskSize != nil {
 		volSize = *r.DiskSize
@@ -133,18 +134,18 @@ func (r *ComputeRequest) onDemandInstance(ctx *pulumi.Context) (*ec2.Instance, e
 		&args,
 		pulumi.DependsOn(r.DependsOn))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	_, err = ec2.NewEipAssociation(ctx,
+	eipAssociation, err := ec2.NewEipAssociation(ctx,
 		resourcesUtil.GetResourceName(r.Prefix, r.ID, "instance-eip"),
 		&ec2.EipAssociationArgs{
 			InstanceId:   instance.ID(),
 			AllocationId: r.Eip.ID(),
 		})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return instance, nil
+	return instance, eipAssociation, nil
 }
 
 // create asg with 1 instance forced by spot


### PR DESCRIPTION
## Summary

- retain the on-demand EIP association resource
- make readiness and subsequent remote commands depend on the association
- prevent SSH retries from masking an `AssociateAddress` provisioning failure

## Context

When `ec2:AssociateAddress` fails, Pulumi currently starts the remote readiness command anyway because it depends only on the instance and EIP resources. The command targets the unattached EIP and reports `Dial N/inf failed: retrying` until its resource timeout.

## Testing

- `git diff --check`
- Go tests not run locally because the Go toolchain is unavailable in the workspace