### PR TITLE
fix(aws): skip S3 cleanup for local backends

### DIFF
--- a/pkg/provider/aws/aws.go
+++ b/pkg/provider/aws/aws.go
@@ -230,6 +230,11 @@ func CleanupState(mCtx *mc.Context) error {
 	if mCtx.IsKeepState() {
 		return nil
 	}
+	// Pulumi manages local state backends itself. The explicit cleanup below is
+	// only needed for state stored in S3.
+	if !data.ValidateS3Path(mCtx.BackedURL()) {
+		return nil
+	}
 
 	bucket, key, parseErr := parseS3BackedURL(mCtx)
 	if parseErr != nil {


### PR DESCRIPTION
## Summary

- skip AWS state-object cleanup for non-S3 Pulumi backends
- avoid warning that a valid `file://` backend is an invalid S3 URI
- preserve parsing and warnings for malformed `s3://` backend URLs

## Testing

- `git diff --check`
- verified commit GPG signature
- Go tests not run because the Go toolchain is unavailable in the workspace